### PR TITLE
Preview crafts with 3D viewer

### DIFF
--- a/app/components/applied-sticker-editor.tsx
+++ b/app/components/applied-sticker-editor.tsx
@@ -107,10 +107,6 @@ export function AppliedStickerEditor({
   const attributes = useKeyValues(value);
   const canPreviewItem =
     slot !== undefined && forItem !== undefined && stickers !== undefined;
-  // Per-model sticker-offset envelope. When the model (or a missing target item)
-  // doesn't publish bounds for an axis, that control is hidden: the value stays
-  // at its 0 default, which sits inside every real envelope, and CS2Inventory is
-  // the authoritative gate for what actually persists.
   const stickerOffsetXMin = forItem?.getMinimumStickerOffsetX();
   const stickerOffsetXMax = forItem?.getMaximumStickerOffsetX();
   const stickerOffsetYMin = forItem?.getMinimumStickerOffsetY();

--- a/app/components/apply-item-sticker.tsx
+++ b/app/components/apply-item-sticker.tsx
@@ -25,7 +25,7 @@ import { useInventory, useTranslate } from "./app-context";
 import { ViewerOverlay } from "./viewer-overlay";
 import { useViewer } from "./hooks/use-viewer";
 import { useViewerAvailability } from "./hooks/use-viewer-availability";
-import { useViewerFallback } from "./hooks/use-viewer-fallback";
+import { useViewerStatus } from "./hooks/use-viewer-status";
 import { ItemImage } from "./item-image";
 import { ModalButton } from "./modal-button";
 import { Overlay } from "./overlay";
@@ -188,7 +188,7 @@ function ApplyItemSticker3d({
     rotation?: number;
   }>({});
 
-  const viewerStatus = useViewerFallback(api);
+  const viewerStatus = useViewerStatus(api);
 
   // Mirror the active sticker's offset/rotation so Apply persists what's shown, and
   // cancel a pending confirmation the moment the user nudges the sticker.

--- a/app/components/apply-item-sticker.tsx
+++ b/app/components/apply-item-sticker.tsx
@@ -33,11 +33,8 @@ import { ScrapeLevelSlider } from "./scrape-level-slider";
 import { UseItemFooter } from "./use-item-footer";
 import { UseItemHeader } from "./use-item-header";
 
-// "Confirm position" stays disabled this long after the weapon loads so the user
-// registers the sticker (pulsed via highlight) before they can lock in the apply.
 const CONFIRM_POSITION_DELAY_MS = 3500;
 
-// Cadence of the highlight sweep during the confirm-delay window (each sweep ~0.7s).
 const HIGHLIGHT_PULSE_INTERVAL_MS = 1000;
 
 interface ApplyItemStickerProps {
@@ -54,9 +51,6 @@ interface StickerPlacement {
   wear?: number;
 }
 
-// Shared commit path: apply the sticker onto an existing weapon, or add a free item
-// carrying it, syncing the same placement, playing the confirm cue, and closing.
-// Used by both the 3D and 2D bodies so they apply identically.
 function useApplySticker(
   targetUid: number,
   stickerUid: number,
@@ -118,14 +112,6 @@ function useApplySticker(
   };
 }
 
-/**
- * Game-like apply: the weapon in the 3D viewer with its already-applied stickers, the
- * one being applied appended on top and active so it (only) can be moved/rotated. A
- * scrape slider sets its wear and "Next preset" cycles its anchor. "Confirm position"
- * unlocks Apply after a short highlight window; nudging the sticker again cancels the
- * confirmation, mirroring the game. If the viewer can't be reached, availability flips
- * and the parent falls back to {@link ApplyItemSticker2d}.
- */
 function ApplyItemSticker3d({
   onClose,
   targetUid,
@@ -139,9 +125,6 @@ function ApplyItemSticker3d({
   const stickerItem = useInventoryItem(stickerUid);
   const maxSchema = targetItem.getStickerSchemaCount();
 
-  // The weapon's already-applied stickers stay fixed context; the sticker being
-  // applied is appended on top of the stack and made active. Seeded once: its stack
-  // index is `newIndex` and lines up 1:1 with the viewer's sticker index.
   const [existing] = useState(() =>
     CS2InventoryItem.stickersToArray(
       Object.fromEntries(targetItem.someStickers()),
@@ -150,14 +133,11 @@ function ApplyItemSticker3d({
   );
   const [newSticker] = useState(() => ({
     id: stickerItem.id,
-    // Anchor on the first free markup slot (bounded by the body's anchor count),
-    // never the stack index — that would overflow on reduced-anchor models.
+    // Anchor on the first free schema, never the stack index (overflows on
+    // reduced-anchor models).
     schema: getNextStickerSchema(existing, maxSchema)
   }));
   const newIndex = existing.length;
-  // The viewer reads its initial stickers from the iframe `src` (captured once), so
-  // hand it the existing stack plus the appended sticker; later changes go through
-  // the api.
   const [initialItem] = useState<CS2BaseInventoryItem>(() => ({
     id: targetItem.id,
     seed: targetItem.seed,
@@ -168,17 +148,12 @@ function ApplyItemSticker3d({
   }));
   const { api, viewerProps } = useViewer({ item: initialItem });
 
-  // Anchor (schema) and wear are driven from here (Next preset / scrape slider); the
-  // offset/rotation are driven inside the viewer and mirrored back via `change`.
   const [schema, setSchema] = useState(newSticker.schema);
   const [wear, setWear] = useState(0);
   const placementRef = useRef<{ x?: number; y?: number; rotation?: number }>(
     {}
   );
 
-  // "Confirm position" is disabled until the weapon has been shown for a moment, then
-  // unlocks Apply; moving/rotating the sticker afterwards cancels it. The refs hold
-  // the live values the once-registered `change` listener reads.
   const [confirmEnabled, setConfirmEnabled] = useState(false);
   const [confirmed, setConfirmed] = useState(false);
   const confirmedRef = useRef(false);
@@ -190,8 +165,6 @@ function ApplyItemSticker3d({
 
   const viewerStatus = useViewerStatus(api);
 
-  // Mirror the active sticker's offset/rotation so Apply persists what's shown, and
-  // cancel a pending confirmation the moment the user nudges the sticker.
   useEffect(() => {
     if (api === undefined) {
       return;
@@ -221,9 +194,6 @@ function ApplyItemSticker3d({
     return () => offChange();
   }, [api, newIndex]);
 
-  // Once the viewer is ready, make the appended sticker active and pulse a highlight
-  // over it through the confirm-delay window so the user notices which one they're
-  // placing before Apply unlocks.
   useEffect(() => {
     if (api === undefined || viewerStatus !== "ready") {
       return;
@@ -252,8 +222,6 @@ function ApplyItemSticker3d({
   function handleNextPreset() {
     const nextSchema = (schema + 1) % maxSchema;
     setSchema(nextSchema);
-    // setStickerSchema re-anchors and zeroes offset/rotation in the viewer; the
-    // `change` echo refreshes placementRef.
     api?.setStickerSchema({ index: newIndex, schema: nextSchema });
   }
 
@@ -373,11 +341,6 @@ function ApplyItemSticker3d({
   );
 }
 
-/**
- * 2D fallback used when the 3D viewer is unavailable (disabled or rate-limited):
- * the weapon image with a "+" on each free markup anchor to choose the new
- * sticker's slot. Persists the chosen `schema` only.
- */
 function ApplyItemSticker2d({
   onClose,
   targetUid,
@@ -391,9 +354,6 @@ function ApplyItemSticker2d({
   const stickerItem = useInventoryItem(stickerUid);
   const targetItem = useInventoryItem(targetUid);
 
-  // v8 stores stickers as a stack array; each sticker's `schema` is the markup
-  // anchor (the in-game slot it sits on). Build the grid from the weapon's markup
-  // positions and offer a "+" on each one no applied sticker occupies.
   const schemaCount = targetItem.getStickerSchemaCount();
   const stickerBySchema = new Map(
     targetItem
@@ -469,13 +429,7 @@ function ApplyItemSticker2d({
   );
 }
 
-/**
- * Apply a sticker onto a weapon. Prefers the 3D viewer (move/rotate the sticker in
- * place); falls back to the 2D anchor picker when the viewer is unavailable.
- */
 export function ApplyItemSticker(props: ApplyItemStickerProps) {
-  // The 3D scene renders the target weapon (with its existing stickers) AND the sticker being
-  // applied, so all of them must be viewer-supported; otherwise fall back to the 2D anchor picker.
   const targetItem = useInventoryItem(props.targetUid);
   const stickerItem = useInventoryItem(props.stickerUid);
   const { canUse3d, isStickerSupported } = useViewerAvailability(targetItem);

--- a/app/components/apply-item-sticker.tsx
+++ b/app/components/apply-item-sticker.tsx
@@ -432,7 +432,9 @@ function ApplyItemSticker2d({
 export function ApplyItemSticker(props: ApplyItemStickerProps) {
   const targetItem = useInventoryItem(props.targetUid);
   const stickerItem = useInventoryItem(props.stickerUid);
-  const { canUse3d, isStickerSupported } = useViewerAvailability(targetItem);
+  const { canUse3d, isStickerSupported } = useViewerAvailability(targetItem, {
+    attachment: true
+  });
   return canUse3d && isStickerSupported(stickerItem.id) ? (
     <ApplyItemSticker3d {...props} />
   ) : (

--- a/app/components/editor-item-display.tsx
+++ b/app/components/editor-item-display.tsx
@@ -12,7 +12,7 @@ import clsx from "clsx";
 import { useEffect, useRef, useState } from "react";
 import { useViewer } from "./hooks/use-viewer";
 import { useViewerAvailability } from "./hooks/use-viewer-availability";
-import { useViewerFallback } from "./hooks/use-viewer-fallback";
+import { useViewerStatus } from "./hooks/use-viewer-status";
 import { ItemEditorName } from "./item-editor-name";
 import { ItemImage } from "./item-image";
 import { Viewer } from "./viewer";
@@ -43,7 +43,7 @@ function EditorItem3dPreview({
     wear
   }));
   const { api, viewerProps } = useViewer({ item: initialItem });
-  useViewerFallback(api);
+  useViewerStatus(api);
   const lastItemRef = useRef(initialItem);
   const imageLoadedRef = useRef(false);
   const [reveal, setReveal] = useState<"pending" | "instant" | "fade">(

--- a/app/components/editor-item-display.tsx
+++ b/app/components/editor-item-display.tsx
@@ -126,10 +126,7 @@ export function EditorItemDisplay({
   stickers,
   wear
 }: EditorItemDisplayProps) {
-  const { canUse3d } = useViewerAvailability(
-    { id: item.id, stickers },
-    { respectStickerEditorPreference: false }
-  );
+  const { canUse3d } = useViewerAvailability({ id: item.id, stickers });
   return (
     <>
       {canUse3d && !item.isSticker() ? (

--- a/app/components/editor-item-display.tsx
+++ b/app/components/editor-item-display.tsx
@@ -3,25 +3,120 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CS2EconomyItem, CS2ItemType } from "@ianlucas/cs2-lib";
+import {
+  CS2BaseInventoryItem,
+  CS2EconomyItem,
+  CS2ItemType
+} from "@ianlucas/cs2-lib";
 import clsx from "clsx";
+import { useEffect, useRef, useState } from "react";
+import { useViewer } from "./hooks/use-viewer";
+import { useViewerAvailability } from "./hooks/use-viewer-availability";
+import { useViewerFallback } from "./hooks/use-viewer-fallback";
 import { ItemEditorName } from "./item-editor-name";
 import { ItemImage } from "./item-image";
+import { Viewer } from "./viewer";
+
+interface EditorItemDisplayProps {
+  item: CS2EconomyItem;
+  nameTag?: string;
+  seed?: number;
+  statTrak?: number;
+  stickers?: CS2BaseInventoryItem["stickers"];
+  wear?: number;
+}
+
+function EditorItem3dPreview({
+  item,
+  nameTag,
+  seed,
+  statTrak,
+  stickers,
+  wear
+}: EditorItemDisplayProps) {
+  const [initialItem] = useState<CS2BaseInventoryItem>(() => ({
+    id: item.id,
+    nameTag,
+    seed,
+    statTrak,
+    stickers,
+    wear
+  }));
+  const { api, viewerProps } = useViewer({ item: initialItem });
+  useViewerFallback(api);
+  const lastItemRef = useRef(initialItem);
+
+  useEffect(() => {
+    if (api === undefined) {
+      return;
+    }
+    const last = lastItemRef.current;
+    const next: CS2BaseInventoryItem = {
+      id: item.id,
+      nameTag,
+      seed,
+      statTrak,
+      stickers,
+      wear
+    };
+    lastItemRef.current = next;
+    if (
+      next.nameTag !== last.nameTag ||
+      next.statTrak !== last.statTrak ||
+      next.stickers !== last.stickers
+    ) {
+      api.setItem(next);
+      return;
+    }
+    if (next.wear !== last.wear && next.wear !== undefined) {
+      api.setWear({ wear: next.wear });
+    }
+    if (next.seed !== last.seed && next.seed !== undefined) {
+      api.setSeed({ seed: next.seed });
+    }
+  }, [api, item.id, nameTag, seed, statTrak, stickers, wear]);
+
+  return (
+    <Viewer
+      {...viewerProps}
+      className="m-auto aspect-256/192 w-[256px] border-0 bg-transparent"
+      icon
+      style={{ colorScheme: "normal" }}
+    />
+  );
+}
 
 export function EditorItemDisplay({
   item,
+  nameTag,
+  seed,
+  statTrak,
+  stickers,
   wear
-}: {
-  item: CS2EconomyItem;
-  wear?: number;
-}) {
+}: EditorItemDisplayProps) {
+  const { canUse3d } = useViewerAvailability(
+    { id: item.id, stickers },
+    { respectStickerEditorPreference: false }
+  );
   return (
     <>
-      <ItemImage
-        className="m-auto w-[256px]"
-        item={item}
-        wear={item.hasWear() ? wear : undefined}
-      />
+      {canUse3d && !item.isSticker() ? (
+        <EditorItem3dPreview
+          key={item.id}
+          item={item}
+          nameTag={nameTag}
+          seed={seed}
+          statTrak={statTrak}
+          stickers={stickers}
+          wear={wear}
+        />
+      ) : (
+        <ItemImage
+          className="m-auto w-[256px]"
+          item={item}
+          wear={item.hasWear() ? wear : undefined}
+        />
+      )}
       <div
         className={clsx(
           "mb-2 text-center",

--- a/app/components/editor-item-display.tsx
+++ b/app/components/editor-item-display.tsx
@@ -45,6 +45,19 @@ function EditorItem3dPreview({
   const { api, viewerProps } = useViewer({ item: initialItem });
   useViewerFallback(api);
   const lastItemRef = useRef(initialItem);
+  const imageLoadedRef = useRef(false);
+  const [reveal, setReveal] = useState<"pending" | "instant" | "fade">(
+    "pending"
+  );
+
+  useEffect(() => {
+    if (api === undefined) {
+      return;
+    }
+    return api.once("rendered", () => {
+      setReveal(imageLoadedRef.current ? "fade" : "instant");
+    });
+  }, [api]);
 
   useEffect(() => {
     if (api === undefined) {
@@ -77,12 +90,31 @@ function EditorItem3dPreview({
   }, [api, item.id, nameTag, seed, statTrak, stickers, wear]);
 
   return (
-    <Viewer
-      {...viewerProps}
-      className="m-auto aspect-256/192 w-[256px] border-0 bg-transparent"
-      icon
-      style={{ colorScheme: "normal" }}
-    />
+    <div className="relative m-auto aspect-256/192 w-[256px]">
+      <ItemImage
+        className={clsx(
+          "absolute inset-0 w-full",
+          reveal === "instant" && "opacity-0",
+          reveal === "fade" &&
+            "opacity-0 transition-opacity delay-1000 duration-1000"
+        )}
+        item={item}
+        onLoad={() => {
+          imageLoadedRef.current = true;
+        }}
+        wear={item.hasWear() ? wear : undefined}
+      />
+      <Viewer
+        {...viewerProps}
+        className={clsx(
+          "absolute inset-0 size-full border-0 bg-transparent",
+          reveal === "pending" && "opacity-0",
+          reveal === "fade" && "transition-opacity duration-1000"
+        )}
+        icon
+        style={{ colorScheme: "normal" }}
+      />
+    </div>
   );
 }
 

--- a/app/components/hold-button.tsx
+++ b/app/components/hold-button.tsx
@@ -9,18 +9,9 @@ import { getTypedFromLocalStorage } from "~/utils/localstorage";
 import { ModalButton } from "./modal-button";
 import { TooltipBubble, useTooltip } from "./tooltip";
 
-// How long the button must be held before it fires; the reddish fill sweeps to full
-// over this window with the loop cue underneath.
 const DEFAULT_HOLD_MS = 2500;
-// Snap-back when released early — fast, so a cancelled hold reads as "let go".
 const REWIND_MS = 150;
 
-/**
- * Press-and-hold button mirroring the game's destructive confirm: holding sweeps a
- * fill across the button and plays a looping cue; completing the hold fires `onHold`,
- * releasing (or leaving) early cancels — the fill rewinds and the cue stops. A tooltip
- * explains the gesture (rendered with `pre-line` so the source `\n` breaks).
- */
 export function HoldButton({
   children,
   durationMs = DEFAULT_HOLD_MS,
@@ -77,7 +68,6 @@ export function HoldButton({
   }
 
   function start(event: PointerEvent<HTMLButtonElement>) {
-    // Ignore non-primary buttons and re-entrant presses so the fill tracks one hold.
     if (props.disabled === true || fireRef.current !== undefined) {
       return;
     }

--- a/app/components/hooks/use-viewer-availability.ts
+++ b/app/components/hooks/use-viewer-availability.ts
@@ -86,17 +86,20 @@ export function markViewerUnsupported(reason: ViewerUnsupportedReason) {
 
 export function useViewerAvailability(
   item?: ViewerItemInput,
-  {
-    respectStickerEditorPreference = true
-  }: { respectStickerEditorPreference?: boolean } = {}
+  { attachment = false }: { attachment?: boolean } = {}
 ) {
-  const { viewerEnabled, viewerOriginAllowed, viewerCatalog } = useRules();
+  const {
+    viewerAttachmentsOnly,
+    viewerEnabled,
+    viewerOriginAllowed,
+    viewerCatalog
+  } = useRules();
   const { prefer2dStickerEditor } = usePreferences();
   const until = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const globalAvailable =
     viewerEnabled === true &&
     viewerOriginAllowed === true &&
-    (!respectStickerEditorPreference || !prefer2dStickerEditor) &&
+    (attachment ? !prefer2dStickerEditor : viewerAttachmentsOnly !== true) &&
     Date.now() >= until;
   const canUse3d =
     globalAvailable &&

--- a/app/components/hooks/use-viewer-availability.ts
+++ b/app/components/hooks/use-viewer-availability.ts
@@ -139,14 +139,14 @@ export function useViewerAvailability(
     respectStickerEditorPreference = true
   }: { respectStickerEditorPreference?: boolean } = {}
 ) {
-  const { appEnable3dViewer, can3dViewerOrigin, viewerCatalog } = useRules();
+  const { viewerEnabled, viewerOriginAllowed, viewerCatalog } = useRules();
   const { prefer2dStickerEditor } = usePreferences();
   const until = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   // The global gate: feature on, origin within budget, no active rate-limit cooldown, and — unless the
   // caller opts out — the user hasn't opted into the 2D editors.
   const globalAvailable =
-    appEnable3dViewer === true &&
-    can3dViewerOrigin === true &&
+    viewerEnabled === true &&
+    viewerOriginAllowed === true &&
     (!respectStickerEditorPreference || !prefer2dStickerEditor) &&
     Date.now() >= until;
   // Item-aware: 3D-eligible only if the viewer can render this item AND all its current stickers.

--- a/app/components/hooks/use-viewer-availability.ts
+++ b/app/components/hooks/use-viewer-availability.ts
@@ -12,34 +12,19 @@ import {
 } from "~/data/viewer";
 import type { ViewerUnsupportedReason } from "~/utils/viewer-api";
 
-// Module-level cooldown shared across the whole app: when the viewer reports a
-// rate limit — for this user via scope "ip", or for the whole instance via
-// scope "origin"/"partner" — we stop offering the 3D viewer until the
-// server-provided backoff elapses, then re-render subscribers so the UI returns
-// to 3D on its own.
 let cooldownUntil = 0;
 let cooldownTimer: ReturnType<typeof setTimeout> | undefined;
 const listeners = new Set<() => void>();
 
-// Cooldown lengths per `unsupported` reason (see markViewerUnsupported).
-const NETWORK_BASE_MS = 30_000; // a transient load failure — try 3D again soon
-const NETWORK_CAP_MS = 8 * 60_000; // ...but cap the exponential backoff
-const WEBGL_COOLDOWN_MS = 5 * 60_000; // device can't do 3D — don't re-probe every 30s
-// How many times in a row the viewer has failed with a transient (network) reason. Drives the
-// exponential backoff so a persistently-blocked CDN (e.g. behind the Great Firewall) settles into 2D
-// instead of ping-ponging the user back to a blank 3D view every 30s. It resets on its OWN — not on
-// the viewer's `ready` handshake, which fires even when the render then fails (that would reset the
-// streak every cycle and defeat the backoff) — via a quiet-period timer: if the cooldown clears and
-// no new failure arrives, the blip passed and the streak returns to zero.
+const NETWORK_BASE_MS = 30_000;
+const NETWORK_CAP_MS = 8 * 60_000;
+const WEBGL_COOLDOWN_MS = 5 * 60_000;
 let networkBackoffStep = 0;
 let backoffResetTimer: ReturnType<typeof setTimeout> | undefined;
-// Extra quiet time after a cooldown clears before we call the streak over: the returned-to-3D viewer
-// must get all the way THROUGH its own retry budget WITHOUT failing again before we count the block as
-// gone. That budget is the viewer's ATTEMPTS × per-attempt TIMEOUT (3 × 30s ≈ 90s in the viewer's
-// fetch-asset.ts) plus its ready handshake, so this must exceed ~90s. Otherwise a persistently STALLING
-// CDN — every attempt times out, so the viewer takes ~90s to fail again — would reset the streak every
-// cycle (its next failure lands after the timer fires) and defeat the backoff, ping-ponging the user
-// between 2D and a ~90s-loading 3D view forever. Keep in step if the viewer's retry budget changes.
+// Quiet time after a cooldown clears before the backoff streak resets. Must
+// exceed the viewer's own retry budget (~90s: 3 attempts x 30s timeout in its
+// fetch-asset.ts), or a persistently stalling CDN would reset the streak every
+// cycle and defeat the backoff.
 const BACKOFF_RESET_GRACE_MS = 120_000;
 
 function emit() {
@@ -63,11 +48,6 @@ function getServerSnapshot() {
   return 0;
 }
 
-/**
- * Records a viewer rate-limit backoff. Called from the viewer overlay's
- * `rateLimited` handler. Extends (never shortens) the cooldown and schedules a
- * re-render for when it elapses so consumers flip back to the 3D viewer.
- */
 export function markViewerRateLimited(retryAfterMs: number) {
   const until = Date.now() + Math.max(0, retryAfterMs);
   if (until <= cooldownUntil) {
@@ -81,16 +61,6 @@ export function markViewerRateLimited(retryAfterMs: number) {
   emit();
 }
 
-/**
- * Records a viewer `unsupported` report, deriving the cooldown from its reason:
- *  - "webgl": the device can't do 3D (WebGL/hardware accel, or a context that keeps dying) — a fixed,
- *    longer suppression, since it won't clear on a 30s retry and the viewer re-probes cheaply anyway.
- *  - "network"/"asset"/unknown: a transient load failure — a short cooldown that backs off
- *    exponentially on repeats (30s → 1m → 2m …, capped) so a persistently-blocked CDN settles into 2D
- *    instead of ping-ponging the user (the streak self-clears via the quiet-period timer above).
- *  - "weapon"/"sticker": a catalog mismatch handled per-item by the viewerCatalog gate — a short cooldown
- *    just covers the current interaction.
- */
 export function markViewerUnsupported(reason: ViewerUnsupportedReason) {
   if (reason === "webgl") {
     markViewerRateLimited(WEBGL_COOLDOWN_MS);
@@ -106,8 +76,6 @@ export function markViewerUnsupported(reason: ViewerUnsupportedReason) {
   );
   networkBackoffStep++;
   markViewerRateLimited(wait);
-  // Arm the quiet-period reset: if nothing fails again before this fires, the streak is over. A new
-  // failure before then reschedules it, so a persistent block keeps climbing the backoff.
   if (backoffResetTimer !== undefined) {
     clearTimeout(backoffResetTimer);
   }
@@ -116,23 +84,6 @@ export function markViewerUnsupported(reason: ViewerUnsupportedReason) {
   }, wait + BACKOFF_RESET_GRACE_MS);
 }
 
-/**
- * Single source of truth for "can we show the 3D viewer right now?", combining
- * the master rule, the server-resolved origin budget verdict, any live
- * rate-limit cooldown, the user's preference to stick with the 2D sticker
- * editors, and — when an `item` is passed — whether the viewer's catalog can
- * render that specific item and every sticker it already carries. The decision
- * is a synchronous read — callers never await — so opening the editor is instant.
- *
- * Pass the item being inspected/crafted/edited/stickered to gate on it (a kind the
- * viewer never renders — music kit, collectible, agent, ... — or a viewer-unknown
- * weapon or existing sticker falls back to 2D). Omit it for a global check, and
- * use `isStickerSupported(id)` to filter per-sticker (e.g. the sticker modal).
- *
- * `prefer2dStickerEditor` is named for (and scoped to) the sticker editors, so the
- * read-only 3D inspect view opts out of it with `respectStickerEditorPreference: false`
- * — it still shares every other signal (master rule, budget, cooldown, catalog).
- */
 export function useViewerAvailability(
   item?: ViewerItemInput,
   {
@@ -142,14 +93,11 @@ export function useViewerAvailability(
   const { viewerEnabled, viewerOriginAllowed, viewerCatalog } = useRules();
   const { prefer2dStickerEditor } = usePreferences();
   const until = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-  // The global gate: feature on, origin within budget, no active rate-limit cooldown, and — unless the
-  // caller opts out — the user hasn't opted into the 2D editors.
   const globalAvailable =
     viewerEnabled === true &&
     viewerOriginAllowed === true &&
     (!respectStickerEditorPreference || !prefer2dStickerEditor) &&
     Date.now() >= until;
-  // Item-aware: 3D-eligible only if the viewer can render this item AND all its current stickers.
   const canUse3d =
     globalAvailable &&
     (item === undefined || isViewerItemSupported(viewerCatalog, item));

--- a/app/components/hooks/use-viewer-status.ts
+++ b/app/components/hooks/use-viewer-status.ts
@@ -10,53 +10,30 @@ import {
   markViewerUnsupported
 } from "./use-viewer-availability";
 
-// How long to wait for the viewer's ready handshake before falling back to the 2D flow,
-// so a down/blocked viewer doesn't strand the user on a blank overlay.
 const VIEWER_READY_TIMEOUT_MS = 6000;
 
 export type ViewerStatus = "pending" | "ready" | "unavailable";
 
-/**
- * Drives the shared "fall back to 2D" policy for a viewer overlay. It records a viewer
- * rate-limit cooldown — skipping transient per-user (`scope: "ip"`) limits, but acting on
- * instance-wide ones — and, if the viewer never reports ready within
- * {@link VIEWER_READY_TIMEOUT_MS}, starts the same cooldown itself. Either way
- * {@link useViewerAvailability} then flips the parent back to the 2D flow.
- *
- * Returns the readiness status so each flow reacts in its own effect: `"ready"` to drive
- * the model, `"unavailable"` (a missed handshake *or* an instance-wide rate limit) to
- * preserve in-progress edits before the swap. `"ready"` and `"unavailable"` are mutually
- * exclusive; an instance-wide rate limit moves a once-`"ready"` viewer to `"unavailable"`.
- */
-export function useViewerStatus(
-  api: ViewerApi | undefined
-): ViewerStatus {
+export function useViewerStatus(api: ViewerApi | undefined): ViewerStatus {
   const [status, setStatus] = useState<ViewerStatus>("pending");
 
   useEffect(() => {
     if (api === undefined) {
       return;
     }
-    // Reset for a fresh api (no-op when already pending); the viewer is created once per
-    // mount, so in practice this only ever transitions pending -> ready|unavailable once.
     setStatus("pending");
-    // `settled` guards the ready-vs-timeout race so only the first of the two wins. An
-    // instance-wide rate limit is independent: it falls back even after `"ready"`.
     let settled = false;
     const timer = setTimeout(() => {
       if (settled) {
         return;
       }
       settled = true;
-      // The viewer never handshook — down/blocked/unreachable. Treat it as a transient network failure
-      // so repeated unreachability climbs the same exponential backoff (no 30s ping-pong).
       markViewerUnsupported("network");
       setStatus("unavailable");
     }, VIEWER_READY_TIMEOUT_MS);
     const offRateLimited = api.on("rateLimited", ({ retryAfterMs, scope }) => {
-      // Per-user limits (scope "ip") are transient and the viewer auto-retries, so let it
-      // recover in place. Instance-wide cases (or an unknown scope) persist, so record the
-      // backoff and fall back — even if the viewer had already become ready.
+      // Per-user ("ip") limits recover in place via the viewer's own retry;
+      // instance-wide ones persist, so fall back even after "ready".
       if (scope === "ip") {
         return;
       }
@@ -65,12 +42,6 @@ export function useViewerStatus(
       clearTimeout(timer);
       setStatus("unavailable");
     });
-    // The viewer reported it can't render the requested item — a WebGL/device failure, an asset/API
-    // load that failed after its own retries (a GFW-blocked CDN), or a cs2-lib catalog mismatch. Fall
-    // back to 2D, with a cooldown whose length the reason decides (markViewerUnsupported): device
-    // failures suppress 3D longer, transient network failures back off on repeats so a blocked CDN
-    // stops ping-ponging the user. This flips the parent off 3D, driving the swap and breaking the
-    // reopen loop.
     const offUnsupported = api.on("unsupported", ({ reason }) => {
       markViewerUnsupported(reason);
       settled = true;

--- a/app/components/hooks/use-viewer-status.ts
+++ b/app/components/hooks/use-viewer-status.ts
@@ -14,7 +14,7 @@ import {
 // so a down/blocked viewer doesn't strand the user on a blank overlay.
 const VIEWER_READY_TIMEOUT_MS = 6000;
 
-export type ViewerFallbackStatus = "pending" | "ready" | "unavailable";
+export type ViewerStatus = "pending" | "ready" | "unavailable";
 
 /**
  * Drives the shared "fall back to 2D" policy for a viewer overlay. It records a viewer
@@ -28,10 +28,10 @@ export type ViewerFallbackStatus = "pending" | "ready" | "unavailable";
  * preserve in-progress edits before the swap. `"ready"` and `"unavailable"` are mutually
  * exclusive; an instance-wide rate limit moves a once-`"ready"` viewer to `"unavailable"`.
  */
-export function useViewerFallback(
+export function useViewerStatus(
   api: ViewerApi | undefined
-): ViewerFallbackStatus {
-  const [status, setStatus] = useState<ViewerFallbackStatus>("pending");
+): ViewerStatus {
+  const [status, setStatus] = useState<ViewerStatus>("pending");
 
   useEffect(() => {
     if (api === undefined) {

--- a/app/components/hooks/use-viewer.ts
+++ b/app/components/hooks/use-viewer.ts
@@ -21,20 +21,20 @@ import { ViewerApi } from "~/utils/viewer-api";
  *     );
  *
  * The partner key and the viewer's base/asset URLs are injected here from the
- * app rules (`app3dViewerKey`, `viewerEmbedUrl`, `viewerAssetsBaseUrl`), so every
+ * app rules (`viewerKey`, `viewerEmbedUrl`, `viewerAssetsBaseUrl`), so every
  * consumer stays in sync — callers pass only the item (and an optional origin).
  */
 export function useViewer(options?: {
   item?: ViewerItemInput;
   origin?: string;
 }) {
-  const { app3dViewerKey, viewerAssetsBaseUrl, viewerEmbedUrl } = useRules();
+  const { viewerKey, viewerAssetsBaseUrl, viewerEmbedUrl } = useRules();
   const [api, setApi] = useState<ViewerApi>();
   return {
     api,
     viewerProps: {
       ...options,
-      apiKey: app3dViewerKey || undefined,
+      apiKey: viewerKey || undefined,
       embedUrl: viewerEmbedUrl || undefined,
       cdn: viewerAssetsBaseUrl || undefined,
       onApi: setApi

--- a/app/components/hooks/use-viewer.ts
+++ b/app/components/hooks/use-viewer.ts
@@ -8,22 +8,6 @@ import { useRules } from "~/components/app-context";
 import { ViewerItemInput } from "~/data/viewer";
 import { ViewerApi } from "~/utils/viewer-api";
 
-/**
- * Owns the viewer api's lifecycle as state, so consumers re-render once it is
- * available. Spread `viewerProps` onto <Viewer/>, then use `api` anywhere:
- *
- *     const { api, viewerProps } = useViewer({ item: inventoryItem });
- *     return (
- *       <>
- *         <Viewer {...viewerProps} className="aspect-video w-full" />
- *         {api && <StickerControls api={api} />}
- *       </>
- *     );
- *
- * The partner key and the viewer's base/asset URLs are injected here from the
- * app rules (`viewerKey`, `viewerEmbedUrl`, `viewerAssetsBaseUrl`), so every
- * consumer stays in sync — callers pass only the item (and an optional origin).
- */
 export function useViewer(options?: {
   item?: ViewerItemInput;
   origin?: string;

--- a/app/components/inspect-item.tsx
+++ b/app/components/inspect-item.tsx
@@ -22,7 +22,7 @@ import { usePreferences, useTranslate, useUser } from "./app-context";
 import { useTimedState } from "./hooks/use-timed-state";
 import { useViewer } from "./hooks/use-viewer";
 import { useViewerAvailability } from "./hooks/use-viewer-availability";
-import { useViewerFallback } from "./hooks/use-viewer-fallback";
+import { useViewerStatus } from "./hooks/use-viewer-status";
 import { InfoIcon } from "./info-icon";
 import { ItemImage } from "./item-image";
 import { ModalButton } from "./modal-button";
@@ -151,7 +151,7 @@ function InspectItem3d({ onClose, uid }: InspectItemProps) {
   const translate = useTranslate();
   const item = useInventoryItem(uid);
   const { api, viewerProps } = useViewer({ item });
-  useViewerFallback(api);
+  useViewerStatus(api);
   const { infoButton, infoTooltip } = useInspectInfo(item);
 
   return (

--- a/app/components/inspect-item.tsx
+++ b/app/components/inspect-item.tsx
@@ -245,9 +245,7 @@ function InspectItem2d({ onClose, uid }: InspectItemProps) {
 
 export function InspectItem({ onClose, uid }: InspectItemProps) {
   const item = useInventoryItem(uid);
-  const { canUse3d } = useViewerAvailability(item, {
-    respectStickerEditorPreference: false
-  });
+  const { canUse3d } = useViewerAvailability(item);
 
   useEffect(() => {
     clientGlobals.inspectedItem = item;

--- a/app/components/item-editor.tsx
+++ b/app/components/item-editor.tsx
@@ -209,7 +209,16 @@ export function ItemEditor({
   }, [attributes.value]);
 
   const display = (
-    <EditorItemDisplay item={item} wear={attributes.value.wear} />
+    <EditorItemDisplay
+      item={item}
+      nameTag={attributes.value.nameTag || undefined}
+      seed={attributes.value.seed}
+      statTrak={
+        attributes.value.statTrak ? (defaults?.statTrak ?? 0) : undefined
+      }
+      stickers={attributes.value.stickers}
+      wear={attributes.value.wear}
+    />
   );
 
   const editor = (

--- a/app/components/item-editor.tsx
+++ b/app/components/item-editor.tsx
@@ -120,7 +120,9 @@ export function ItemEditor({
 
   const translate = useTranslate();
   const isDesktop = useIsDesktop();
-  const { canUse3d, isStickerSupported } = useViewerAvailability(item);
+  const { canUse3d, isStickerSupported } = useViewerAvailability(item, {
+    attachment: true
+  });
 
   const use3dStickerPicker =
     canUse3d &&

--- a/app/components/item-editor.tsx
+++ b/app/components/item-editor.tsx
@@ -120,12 +120,8 @@ export function ItemEditor({
 
   const translate = useTranslate();
   const isDesktop = useIsDesktop();
-  // Item-aware: `canUse3d` also folds in whether the viewer can render THIS item and its existing
-  // stickers, so a viewer-unknown weapon/sticker keeps the 2D editor.
   const { canUse3d, isStickerSupported } = useViewerAvailability(item);
 
-  // The 3D viewer edits every sticker dimension, so only offer it when none are
-  // constrained (and not in the read-only/disabled view).
   const use3dStickerPicker =
     canUse3d &&
     !isDisabled &&
@@ -135,8 +131,6 @@ export function ItemEditor({
     !isHideStickerX &&
     !isHideStickerY;
 
-  // In 3D, hide stickers the viewer can't render (newer than its cs2-lib) so the user only picks ones
-  // it can show; the 2D picker keeps the full list. Composes with any caller-provided stickerFilter.
   const sticker3dFilter = useCallback(
     (economyItem: CS2EconomyItem) =>
       isStickerSupported(economyItem.id) &&
@@ -386,9 +380,6 @@ export function ItemEditor({
     <div
       className={clsx(
         "m-auto mt-4 text-sm select-none",
-        // Own the width so the surrounding modal (sized to content) grows when
-        // we switch to two columns. w-105 (420px) matches the previous
-        // single-column modal width.
         isTwoColumn ? "w-160" : "w-105",
         className
       )}

--- a/app/components/scrape-item-sticker.tsx
+++ b/app/components/scrape-item-sticker.tsx
@@ -37,8 +37,6 @@ import { ScrapeLevelSlider } from "./scrape-level-slider";
 import { UseItemFooter } from "./use-item-footer";
 import { UseItemHeader } from "./use-item-header";
 
-// How long the "remove sticker" button must be held to confirm; shorter than
-// HoldButton's default since removal is a single, low-stakes action.
 const REMOVE_STICKER_HOLD_MS = 1500;
 
 interface ScrapeItemStickerProps {
@@ -46,20 +44,11 @@ interface ScrapeItemStickerProps {
   uid: number;
 }
 
-// The scrape flow's hook only nudges the 3D model (wear preview + highlight); in the
-// 2D fallback these are no-ops. Keeps the shared logic blind to whether a viewer is up.
 interface ScrapeViewer {
   highlight: (index: number) => void;
   setWear: (index: number, wear: number) => void;
 }
 
-/**
- * Shared scrape/remove logic for both the 3D and 2D flows. Selecting a sticker seeds
- * the slider from its committed wear and highlights it on the model; dragging previews
- * the new wear live (restoring the previously-selected sticker so an uncommitted
- * preview doesn't leak). SCRAPE commits the slider value; REMOVE destroys the sticker
- * and closes. `viewer` drives the 3D model, or no-ops in 2D.
- */
 function useScrapeSticker({
   onClose,
   uid,
@@ -75,14 +64,11 @@ function useScrapeSticker({
 
   const [selectedIndex, setSelectedIndex] = useState<number>();
   const [wear, setWear] = useState(0);
-  // The sticker last shown in the viewer, so we can restore its committed wear when
-  // the selection moves on without a scrape.
   const previewedIndexRef = useRef<number | undefined>(undefined);
 
   const committedWear =
     selectedIndex !== undefined ? item.getStickerWear(selectedIndex) : 0;
-  // Up to one factor below full so scraping never trips cs2-lib's wear-1 removal —
-  // removal is the REMOVE button's job alone.
+  // One factor below full so scraping never trips cs2-lib's wear-1 removal.
   const maxWear = CS2_MAX_STICKER_WEAR - CS2_STICKER_WEAR_FACTOR;
   const canScrape = selectedIndex !== undefined && wear > committedWear;
 
@@ -101,8 +87,6 @@ function useScrapeSticker({
     if (selectedIndex === undefined) {
       return;
     }
-    // The slider spans the full 0..max track (so the thumb sits at the absolute
-    // wear), but you can't scrape below the sticker's current wear — floor it.
     const clamped = Math.max(committedWear, nextWear);
     setWear(clamped);
     viewer.setWear(selectedIndex, clamped);
@@ -117,8 +101,6 @@ function useScrapeSticker({
     setInventory(inventory.scrapeItemSticker(uid, index, wear));
     playSound("sticker_scratch1");
     viewer.highlight(index);
-    // The new committed wear is now `wear`, so the slider locks at its min until the
-    // user drags up again — matching the game's "scrape further from here".
   }
 
   function handleRemove() {
@@ -147,11 +129,6 @@ function useScrapeSticker({
   };
 }
 
-/**
- * The applied-sticker thumbnails listed near the footer. The selected one is full-size
- * and opaque with a green check dropping in and a flash; the rest shrink and fade,
- * popping back to full size (but still transparent) on hover.
- */
 function ScrapeStickerRow({
   item,
   onSelect,
@@ -162,8 +139,6 @@ function ScrapeStickerRow({
   selectedIndex: number | undefined;
 }) {
   const { statsForNerds } = usePreferences();
-  // Bumped on every click so the green check + sticker flash replay each time a sticker
-  // is (re)selected, not only when the selected index changes.
   const [flashNonce, setFlashNonce] = useState(0);
   function handleSelect(index: number) {
     setFlashNonce((nonce) => nonce + 1);
@@ -179,10 +154,6 @@ function ScrapeStickerRow({
             className="group relative flex flex-col items-center"
             onClick={() => handleSelect(index)}
           >
-            {/* One scaling container holds both the check and the sticker, so they scale
-                (and, via their keyed inner wrappers, flash + pop) together. The check
-                sits behind the image (z-0 vs z-10) and additionally fades + slides down
-                to up on select, and back on deselect. */}
             <div
               className={clsx(
                 "relative drop-shadow-lg transition-all",
@@ -200,7 +171,6 @@ function ScrapeStickerRow({
                 )}
               >
                 <span
-                  // Remounts on (re)selection so the flash + scale overshoot replay.
                   key={selected ? `check-${flashNonce}` : "check"}
                   className={clsx(
                     "flex size-6.5 items-center justify-center rounded-full bg-green-600 shadow-md",
@@ -237,11 +207,6 @@ function ScrapeStickerRow({
   );
 }
 
-/**
- * The shared bottom region: the sticker row, the scrape-level slider (present but
- * invisible until a sticker is selected, so the layout doesn't jump), and the
- * REMOVE/SCRAPE/CLOSE footer. Used by both the 3D and 2D shells.
- */
 function ScrapeStickerControls({
   canRemove,
   canScrape,
@@ -326,12 +291,6 @@ function ScrapeStickerControls({
   );
 }
 
-/**
- * Game-like scrape/remove: the weapon in the 3D viewer with its applied stickers.
- * Selecting a sticker highlights it on the model; the slider previews its wear live.
- * If the viewer can't be reached, availability flips and the parent falls back to
- * {@link ScrapeItemSticker2d}.
- */
 function ScrapeItemSticker3d({ onClose, uid }: ScrapeItemStickerProps) {
   const translate = useTranslate();
   const nameItemString = useNameItemString();
@@ -339,9 +298,6 @@ function ScrapeItemSticker3d({ onClose, uid }: ScrapeItemStickerProps) {
 
   const item = useInventoryItem(uid);
   const maxSchema = item.getStickerSchemaCount();
-  // The viewer reads its initial stickers from the iframe `src` (captured once); seed
-  // it from the weapon's current stack, normalized so the viewer's sticker indices
-  // line up 1:1 with `someStickers()`.
   const [initialItem] = useState<CS2BaseInventoryItem>(() => ({
     id: item.id,
     seed: item.seed,
@@ -366,8 +322,8 @@ function ScrapeItemSticker3d({ onClose, uid }: ScrapeItemStickerProps) {
     }
   });
 
-  // Flip availability when the viewer is rate-limited or never becomes ready, so the
-  // parent swaps to the 2D flow; the scrape flow itself needs no readiness handling.
+  // Bare call: flips availability so the parent swaps to 2D when the viewer
+  // is rate-limited or never becomes ready.
   useViewerStatus(api);
 
   return (
@@ -402,11 +358,6 @@ function ScrapeItemSticker3d({ onClose, uid }: ScrapeItemStickerProps) {
   );
 }
 
-/**
- * 2D fallback used when the 3D viewer is unavailable (disabled or rate-limited): the
- * weapon image with the same select/scrape/remove controls, minus the live wear
- * preview the model would show.
- */
 function ScrapeItemSticker2d({ onClose, uid }: ScrapeItemStickerProps) {
   const translate = useTranslate();
   const nameItemString = useNameItemString();
@@ -451,13 +402,7 @@ function ScrapeItemSticker2d({ onClose, uid }: ScrapeItemStickerProps) {
   );
 }
 
-/**
- * Scrape or remove a sticker from a weapon. Prefers the 3D viewer (live wear preview
- * on the model); falls back to the 2D flow when the viewer is unavailable.
- */
 export function ScrapeItemSticker(props: ScrapeItemStickerProps) {
-  // The 3D scene renders the weapon with its existing stickers, so the weapon and every sticker must
-  // be viewer-supported; otherwise fall back to the 2D flow.
   const item = useInventoryItem(props.uid);
   const { canUse3d } = useViewerAvailability(item);
   return canUse3d ? (

--- a/app/components/scrape-item-sticker.tsx
+++ b/app/components/scrape-item-sticker.tsx
@@ -29,7 +29,7 @@ import { ViewerOverlay } from "./viewer-overlay";
 import { HoldButton } from "./hold-button";
 import { useViewer } from "./hooks/use-viewer";
 import { useViewerAvailability } from "./hooks/use-viewer-availability";
-import { useViewerFallback } from "./hooks/use-viewer-fallback";
+import { useViewerStatus } from "./hooks/use-viewer-status";
 import { ItemImage } from "./item-image";
 import { ModalButton } from "./modal-button";
 import { Overlay } from "./overlay";
@@ -368,7 +368,7 @@ function ScrapeItemSticker3d({ onClose, uid }: ScrapeItemStickerProps) {
 
   // Flip availability when the viewer is rate-limited or never becomes ready, so the
   // parent swaps to the 2D flow; the scrape flow itself needs no readiness handling.
-  useViewerFallback(api);
+  useViewerStatus(api);
 
   return (
     <ViewerOverlay

--- a/app/components/scrape-item-sticker.tsx
+++ b/app/components/scrape-item-sticker.tsx
@@ -404,7 +404,7 @@ function ScrapeItemSticker2d({ onClose, uid }: ScrapeItemStickerProps) {
 
 export function ScrapeItemSticker(props: ScrapeItemStickerProps) {
   const item = useInventoryItem(props.uid);
-  const { canUse3d } = useViewerAvailability(item);
+  const { canUse3d } = useViewerAvailability(item, { attachment: true });
   return canUse3d ? (
     <ScrapeItemSticker3d {...props} />
   ) : (

--- a/app/components/scrape-level-slider.tsx
+++ b/app/components/scrape-level-slider.tsx
@@ -11,20 +11,8 @@ import {
 import { useEffect, useRef } from "react";
 import { getTypedFromLocalStorage } from "~/utils/localstorage";
 
-// Minimum gap between scratch cues while dragging — throttles continuous movement into
-// a discrete scratch every 500ms instead of a glitchy buzz.
 const SCRATCH_THROTTLE_MS = 500;
 
-/**
- * In-game "sticker scrape level" slider: a bare track with a filled progress portion
- * and a square thumb, driving a sticker's wear. Deliberately not the craft editor's
- * `EditorStepRange` — that thin/round look doesn't match the game. Shared by the apply
- * and scrape flows.
- *
- * Two in-game behaviors live here so both flows get them: the scratch cue plays only
- * while the (controlled) value is actually moving — throttled, and silent when a drag
- * is pinned against a clamped floor — and the keyboard can't nudge it (pointer only).
- */
 export function ScrapeLevelSlider({
   disabled,
   max = CS2_MAX_STICKER_WEAR,
@@ -38,16 +26,11 @@ export function ScrapeLevelSlider({
   onChange: (wear: number) => void;
   value: number;
 }) {
-  // Reused <audio> (lazily created client-side), whether the handle is being dragged,
-  // the last value we scratched at, and the last scratch timestamp (for the throttle).
   const scratchRef = useRef<HTMLAudioElement | undefined>(undefined);
   const draggingRef = useRef(false);
   const prevValueRef = useRef(value);
   const lastScratchRef = useRef(0);
 
-  // Scratch only when the controlled value actually moves during a drag (so a drag
-  // pinned against the clamped floor, or a programmatic change like selecting another
-  // sticker, stays silent), throttled to a steady cadence.
   useEffect(() => {
     const previous = prevValueRef.current;
     prevValueRef.current = value;
@@ -80,15 +63,12 @@ export function ScrapeLevelSlider({
     }
   }
 
-  // Cut any in-flight scratch if the slider unmounts mid-drag (overlay closed on remove).
   useEffect(() => {
     return () => {
       scratchRef.current?.pause();
     };
   }, []);
 
-  // Fill tracks the thumb within [min, max]; guard the degenerate min === max case
-  // (a sticker already at the scrape cap) so the width never becomes NaN.
   const filled =
     max > min
       ? Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100))
@@ -108,7 +88,7 @@ export function ScrapeLevelSlider({
         min={min}
         onBlur={stopScratching}
         onChange={(event) => onChange(Number(event.target.value))}
-        // Pointer only, like the game — block arrow/home/end/page stepping but keep Tab.
+        // Pointer only, like the game; keep Tab.
         onKeyDown={(event) => {
           if (event.key !== "Tab") {
             event.preventDefault();

--- a/app/components/select-sticker-modal.tsx
+++ b/app/components/select-sticker-modal.tsx
@@ -15,12 +15,6 @@ import { IconSelect } from "./icon-select";
 import { ItemBrowser } from "./item-browser";
 import { Modal, ModalHeader, ModalNav } from "./modal";
 
-/**
- * The "pick a sticker" modal: a searchable, category-filtered browser of every
- * sticker. Shared by the 2D {@link StickerPicker} and the 3D
- * {@link Sticker3dPicker} so both select stickers the same way. `onSelect` fires
- * with the chosen economy item; the caller owns what slot it lands in.
- */
 export function SelectStickerModal({
   fixed,
   hidden,

--- a/app/components/sticker-3d-picker.tsx
+++ b/app/components/sticker-3d-picker.tsx
@@ -27,7 +27,7 @@ import { AppliedStickerEditor } from "./applied-sticker-editor";
 import { ButtonWithTooltip } from "./button-with-tooltip";
 import { ViewerOverlay } from "./viewer-overlay";
 import { useViewer } from "./hooks/use-viewer";
-import { useViewerFallback } from "./hooks/use-viewer-fallback";
+import { useViewerStatus } from "./hooks/use-viewer-status";
 import { useNameItemString } from "./hooks/use-name-item";
 import { ItemImage } from "./item-image";
 import { ModalButton } from "./modal-button";
@@ -221,7 +221,7 @@ function Sticker3dEditorOverlay({
     onChangeRef.current = onChange;
   }, [onChange, onClose]);
 
-  const viewerStatus = useViewerFallback(api);
+  const viewerStatus = useViewerStatus(api);
 
   // The viewer became unavailable (never ready, or an instance-wide rate limit):
   // preserve in-progress edits into the 2D fallback, then close so the parent swaps.

--- a/app/components/sticker-3d-picker.tsx
+++ b/app/components/sticker-3d-picker.tsx
@@ -37,38 +37,26 @@ import { StickerSlotGrid } from "./sticker-slot-grid";
 import { UseItemFooter } from "./use-item-footer";
 import { UseItemHeader } from "./use-item-header";
 
-// After a form edit, ignore the viewer's `change` echoes for this long so the
-// panel isn't remounted from under an active slider (which made dragging stick).
+// Window to ignore the viewer's `change` echo of our own form edits, so the
+// panel isn't remounted under an active slider.
 const FORM_ECHO_WINDOW_MS = 400;
 
 type Stickers = NonNullable<CS2BaseInventoryItem["stickers"]>;
 type Sticker = Stickers[string];
 
-// Sticker names are "<localized category> | <name>"; the rail shows just the part
-// after the first "|" (locale-safe — only the separator is constant).
 function stickerName(name: string): string {
   const separator = name.indexOf("|");
   return separator === -1 ? name : name.slice(separator + 1).trim();
 }
 
-// Seed the editor's working array from stored data. cs2-lib sorts by key, caps at
-// CS2_MAX_STICKERS, materializes each `schema` from its key when absent, and heals
-// any anchor outside [0, maxSchema) onto a free one — the same normalization the
-// viewer and the server validator run, so our stack index lines up 1:1 with the
-// viewer's sticker index. The stack index (draw order) and the `schema` (markup
-// anchor) are separate axes; they diverge on reduced-anchor models like the AK-47 HD.
 function toArray(stickers: Stickers, maxSchema: number): Sticker[] {
   return CS2InventoryItem.stickersToArray(stickers, maxSchema);
 }
 
-// Serialize the working array back into the stored record (contiguous 0-based keys,
-// `schema` always set, default wear/offsets dropped) for `onChange` and the viewer.
 function toRecord(stickers: Sticker[]): Stickers {
   return CS2InventoryItem.stickersFromArray(stickers) ?? {};
 }
 
-// Value-equality on the stack array; used to ignore the viewer's echo of our own
-// edits (so only genuine in-viewer edits re-seed the form).
 function stickersEqual(a: Sticker[], b: Sticker[]): boolean {
   if (a.length !== b.length) {
     return false;
@@ -87,10 +75,6 @@ function stickersEqual(a: Sticker[], b: Sticker[]): boolean {
   });
 }
 
-// Vertical drawer handle shared by both panels: a compact bookmark tab on the
-// panel's inner edge that doubles as the collapse/expand toggle. `edge` is the
-// screen side the panel lives on; the corners facing away from the body (toward
-// the viewer) get rounded so it reads as a tab in both open and collapsed states.
 function DrawerTab({
   className,
   edge,
@@ -105,8 +89,6 @@ function DrawerTab({
   return (
     <button
       className={clsx(
-        // self-stretch so the tab spans the panel's content height; bg/shadow come
-        // from the caller so each tab can match its panel (rows vs. solid editor).
         "font-display pointer-events-auto flex shrink-0 items-center justify-center self-stretch px-1.5 py-3 text-sm font-bold text-neutral-200 transition",
         edge === "left" ? "rounded-r" : "rounded-l",
         className
@@ -121,15 +103,6 @@ function DrawerTab({
   );
 }
 
-/**
- * Full-screen 3D editor: the weapon in the viewer iframe, a left rail of sticker
- * slots, and a right attributes panel for the selected slot. Slots can be added,
- * removed, reordered (drag = draw order) and edited; edits push to the live viewer
- * but only stage locally — they persist up through `onChange` when the user clicks
- * Apply (close/cancel discards them). In-viewer offset/rotation edits flow back into
- * the panel. The rail/panel are the only pointer targets — the space around
- * them passes through to the iframe so the model stays orbitable.
- */
 function Sticker3dEditorOverlay({
   forItem,
   nameTag,
@@ -154,21 +127,11 @@ function Sticker3dEditorOverlay({
   const translate = useTranslate();
   const nameItemString = useNameItemString();
 
-  // The weapon's markup-anchor count (e.g. 4 for the AK-47 HD body). A sticker's
-  // `schema` must stay in [0, maxSchema); the stack index / draw order is a separate
-  // axis capped at CS2_MAX_STICKERS, so the two diverge on reduced-anchor models —
-  // conflating them is what put an invalid schema (4) on the AK-47 HD's 5th slot.
   const maxSchema = forItem.getStickerSchemaCount();
 
-  // Working copy for this editing session, held as the stack array cs2-lib stores:
-  // the array index is draw order and == the viewer's sticker index, so index-based
-  // api calls line up. Seeded from `value` once; the parent is updated through
-  // `onChange` only on Apply (not vice versa), so edits never flow back mid-session.
   const [stickers, setStickers] = useState<Sticker[]>(() =>
     toArray(value, maxSchema)
   );
-  // The viewer reads its initial stickers from the iframe `src` (captured once), so
-  // hand it the same normalized snapshot; later changes go through the api.
   const [initialItem] = useState<CS2BaseInventoryItem>(() => ({
     id: forItem.id,
     seed,
@@ -180,29 +143,16 @@ function Sticker3dEditorOverlay({
   const { api, viewerProps } = useViewer({ item: initialItem });
 
   const [selected, setSelected] = useState<number>();
-  // Both panels are collapsible drawers. The left ("Stickers") is a plain toggle,
-  // open by default. The right (attributes) opens itself for the selected sticker,
-  // but once the user collapses it the choice sticks — selecting other stickers
-  // won't re-open it; only the tab does (`userCollapsedRight`). `rightEntered`
-  // drives the slide+fade the first time the panel appears for a selection.
   const [leftOpen, setLeftOpen] = useState(true);
   const [userCollapsedRight, setUserCollapsedRight] = useState(false);
   const [rightEntered, setRightEntered] = useState(false);
   const [selecting, setSelecting] = useState<
     { mode: "add" } | { mode: "replace"; index: number }
   >();
-  // Bumped when an in-viewer edit changes our data, to remount the attributes form
-  // so its sliders re-seed to the new values.
   const [formVersion, setFormVersion] = useState(0);
-  // Drag-to-reorder. `dragIndex` is the row being dragged; `dragDelta` translates it
-  // to follow the cursor (the "ghost"); `dragTarget` is the display position it will
-  // drop into (other rows slide to open that gap). Geometry is captured once at drag
-  // start (refs) so hit-testing never re-measures mid-drag.
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [dragDelta, setDragDelta] = useState(0);
   const [dragTarget, setDragTarget] = useState(0);
-  // Suppresses row transitions for the single frame after a drop, so the transform
-  // reset snaps instead of replaying the slide animation.
   const [noTransition, setNoTransition] = useState(false);
   const isDragging = dragIndex !== null;
 
@@ -223,8 +173,6 @@ function Sticker3dEditorOverlay({
 
   const viewerStatus = useViewerStatus(api);
 
-  // The viewer became unavailable (never ready, or an instance-wide rate limit):
-  // preserve in-progress edits into the 2D fallback, then close so the parent swaps.
   useEffect(() => {
     if (viewerStatus !== "unavailable") {
       return;
@@ -233,18 +181,11 @@ function Sticker3dEditorOverlay({
     onCloseRef.current();
   }, [viewerStatus]);
 
-  // Mirror edits made inside the viewer (e.g. dragging a sticker's offset) back into
-  // our local working copy + the form (not the parent — that waits for Apply). We ignore
-  // echoes of our own edits via value-equality so the form isn't remounted from under an
-  // active slider.
   useEffect(() => {
     if (api === undefined) {
       return;
     }
     const offChange = api.on("change", ({ item }) => {
-      // Our own form edits round-trip back as `change`; ignore them briefly so the
-      // panel isn't remounted under an active slider. Genuine in-viewer edits (no
-      // recent form edit) fall through and re-seed the form.
       if (Date.now() - lastEditAtRef.current < FORM_ECHO_WINDOW_MS) {
         return;
       }
@@ -264,8 +205,6 @@ function Sticker3dEditorOverlay({
   const selectedSticker =
     selected !== undefined ? stickers[selected] : undefined;
 
-  // Capture the row pitch once the drag begins (rows are uniform, no transforms
-  // applied yet), so move math is a stable delta -> slot conversion.
   useLayoutEffect(() => {
     if (dragIndex === null) {
       return;
@@ -277,8 +216,6 @@ function Sticker3dEditorOverlay({
     }
   }, [dragIndex]);
 
-  // Re-enable row transitions the frame after a drop, once the snapped layout has
-  // painted (so future reorders animate again without re-animating this drop).
   useEffect(() => {
     if (!noTransition) {
       return;
@@ -287,9 +224,6 @@ function Sticker3dEditorOverlay({
     return () => cancelAnimationFrame(raf);
   }, [noTransition]);
 
-  // Play the right panel's slide+fade-in the first time it mounts for a selection;
-  // reset once nothing is selected so it re-plays on the next one. Keyed on the
-  // has/has-not boundary so switching between selected stickers doesn't re-animate.
   const hasSelectedSticker = selectedSticker !== undefined;
   useEffect(() => {
     if (!hasSelectedSticker) {
@@ -300,17 +234,11 @@ function Sticker3dEditorOverlay({
     return () => cancelAnimationFrame(raf);
   }, [hasSelectedSticker]);
 
-  // Stage edits into the local working copy (+ ref) only. The parent is committed
-  // through `onChange` on Apply (handleApply), not here; the viewer is updated
-  // separately by callers.
   function stageStickers(next: Sticker[]) {
     stickersRef.current = next;
     setStickers(next);
   }
 
-  // Commit the staged working copy up to the parent, then close. Wired to the
-  // primary "Apply" button (and the involuntary-close paths) so edits only persist
-  // on an explicit apply — closing/cancelling discards them.
   function handleApply() {
     onChangeRef.current(toRecord(stickersRef.current));
     onCloseRef.current();
@@ -338,9 +266,8 @@ function Sticker3dEditorOverlay({
         return;
       }
       const index = count;
-      // Draw-order index is `index`; the markup anchor is the first free schema (which
-      // may overlap an existing one once the body's anchors run out), never the stack
-      // index — that would overflow on reduced-anchor models like the AK-47 HD.
+      // Anchor on the first free schema, never the stack index (overflows on
+      // reduced-anchor models like the AK-47 HD).
       const schema = getNextStickerSchema(stickers, maxSchema);
       const next = [...stickers, { id: item.id, schema }];
       api?.addSticker({ id: item.id, schema });
@@ -362,8 +289,6 @@ function Sticker3dEditorOverlay({
     const next = stickers.filter((_, i) => i !== index);
     api?.removeSticker({ index });
     stageStickers(next);
-    // Removing compacts the stack: anything below `index` shifts up one, so keep the
-    // current selection pointing at the same sticker (or drop it if it was removed).
     if (selected === index) {
       setSelected(undefined);
       api?.setActiveSticker({ index: null });
@@ -395,8 +320,7 @@ function Sticker3dEditorOverlay({
       if (current === undefined) {
         return;
       }
-      // -1 is the form's "auto": resolve to the first anchor not used by the other
-      // stickers (bounded by the body's anchor count), never the stack index.
+      // -1 is the form's "auto": the first anchor not used by the other stickers.
       const schema =
         data.schema === -1
           ? getNextStickerSchema(
@@ -404,8 +328,6 @@ function Sticker3dEditorOverlay({
               maxSchema
             )
           : data.schema;
-      // AppliedStickerEditor fires once on mount with the seeded values; skip
-      // no-ops so we neither spam the viewer nor churn parent state.
       if (
         (current.rotation ?? 0) === (data.rotation || 0) &&
         (current.wear ?? 0) === (data.wear || 0) &&
@@ -415,7 +337,6 @@ function Sticker3dEditorOverlay({
       ) {
         return;
       }
-      // Mark this as a local edit so the resulting `change` echo is ignored.
       lastEditAtRef.current = Date.now();
       if ((current.wear ?? 0) !== (data.wear || 0)) {
         api?.setStickerWear({ index, wear: data.wear });
@@ -429,9 +350,6 @@ function Sticker3dEditorOverlay({
       if ((current.rotation ?? 0) !== (data.rotation || 0)) {
         api?.setStickerRotation({ index, rotation: data.rotation });
       }
-      // The viewer resets offset+rotation when the anchor changes, and our form
-      // mirrors that (isResetPlacementOnSchema), so a plain setStickerSchema keeps
-      // both sides in sync.
       if ((current.schema ?? index) !== schema) {
         api?.setStickerSchema({ index, schema });
       }
@@ -493,12 +411,9 @@ function Sticker3dEditorOverlay({
     const from = dragStartPosRef.current;
     const to = dragTargetRef.current;
     dragIndexRef.current = null;
-    // Snap the dropped row + slid rows to their final layout without animating the
-    // transform reset (otherwise the slide replays instead of the ghost settling).
     setNoTransition(true);
     setDragIndex(null);
     setDragDelta(0);
-    // Commit before releasing capture so a release hiccup can't drop the reorder.
     if (to !== from) {
       const next = stickers.slice();
       const [moved] = next.splice(from, 1);
@@ -546,31 +461,19 @@ function Sticker3dEditorOverlay({
           stickerHint
         />
       }
-      viewerClassName={
-        // While dragging, let pointer events skip the iframe so it can't swallow the
-        // move/up that the rail's pointer capture needs.
-        isDragging ? "pointer-events-none" : undefined
-      }
+      viewerClassName={isDragging ? "pointer-events-none" : undefined}
       viewerProps={viewerProps}
     >
-      {/* Wrappers are pointer-events-none so the space around the tiles passes
-          through to the iframe; only the tiles/controls opt back in. The drawer
-          row slides out behind its tab on collapse; the overlay's overflow-hidden
-          clips the off-screen body so it can't extend the page. */}
       <div className="pointer-events-none absolute inset-y-0 left-0 flex h-full items-center p-4">
         <div
           className={clsx(
             "flex max-h-full items-center transition-transform duration-150 ease-out",
-            // Collapsed: shift left by the body width (w-80) + wrapper padding (p-4
-            // = 1rem), i.e. 21rem, so only the tab stays on screen.
             !leftOpen && "-translate-x-84"
           )}
         >
           <div
             className={clsx(
               "pointer-events-none flex max-h-full w-80 flex-col gap-1",
-              // Drop the scroll clip while dragging so the cursor-following ghost
-              // isn't cut off; the list is short enough to fit.
               isDragging ? "overflow-visible" : "overflow-y-auto"
             )}
           >
@@ -585,10 +488,6 @@ function Sticker3dEditorOverlay({
                     rowRefs.current[position] = element;
                   }}
                   className={clsx(
-                    // rounded-l only: the square right edge butts flush into the
-                    // full-height "Stickers" tab so the row merges into it. `group`
-                    // so the thumbnail's blue outline lights on hover of the whole
-                    // row, not just the small thumbnail (matches the empty slots).
                     "group pointer-events-auto overflow-hidden rounded-l",
                     isDragged
                       ? "z-10 bg-neutral-800 shadow-lg"
@@ -629,10 +528,6 @@ function Sticker3dEditorOverlay({
                       title={translate("EditorStickerEdit")}
                     >
                       <ItemImage item={item} />
-                      {/* Blue hover outline matching the inline grid tiles that open
-                          this overlay; an overlay so the image stays full-bleed.
-                          group-hover keys it to the row so it shows like the empty
-                          slots do. */}
                       <div className="absolute top-0 left-0 size-full border-2 border-transparent group-hover:border-blue-500/50" />
                     </button>
                     <span className="flex-1 truncate px-1 text-sm text-neutral-200">
@@ -673,19 +568,12 @@ function Sticker3dEditorOverlay({
           />
         </div>
       </div>
-      {/* Right attributes drawer — mounts while a slot is selected and slides +
-          fades in; its tab collapses it back behind the right edge. */}
       <div className="pointer-events-none absolute inset-y-0 right-0 flex h-full items-center p-4">
         {selected !== undefined && selectedSticker !== undefined && (
           <div
             className={clsx(
-              // Bare `transition` (not the arbitrary transform,opacity list, which
-              // didn't generate) so both the slide and the fade animate.
               "flex max-h-full items-center transition duration-150 ease-out",
               rightEntered ? "opacity-100" : "opacity-0",
-              // Collapsed (and the pre-enter start state) sits one body width (w-90)
-              // + wrapper padding (p-4 = 1rem), i.e. 23.5rem, off the right edge so
-              // only the tab shows.
               userCollapsedRight || !rightEntered
                 ? "translate-x-94"
                 : "translate-x-0"
@@ -752,11 +640,6 @@ function Sticker3dEditorOverlay({
   );
 }
 
-/**
- * 3D counterpart to {@link StickerPicker}: an inline grid that launches the
- * full-screen {@link Sticker3dEditorOverlay}, where stickers are added, removed,
- * reordered, and edited against a live 3D preview of the weapon.
- */
 export function Sticker3dPicker({
   disabled,
   forItem,

--- a/app/components/sticker-slot-grid.tsx
+++ b/app/components/sticker-slot-grid.tsx
@@ -14,12 +14,6 @@ import { range } from "~/utils/number";
 import { useTranslate } from "./app-context";
 import { ItemImage } from "./item-image";
 
-/**
- * The weapon's sticker slots as a fixed grid (one cell per markup slot): each filled slot
- * shows its sticker, empty slots show a placeholder, and clicking a slot calls
- * `onSlotClick`. Shared by the 2D {@link StickerPicker} and the 3D {@link Sticker3dPicker};
- * the 2D picker layers its per-slot remove/edit buttons on via `renderSlotOverlay`.
- */
 export function StickerSlotGrid({
   disabled,
   onSlotClick,
@@ -28,7 +22,6 @@ export function StickerSlotGrid({
 }: {
   disabled?: boolean;
   onSlotClick: (index: number) => void;
-  // Extra controls drawn over a filled, enabled slot (e.g. remove/edit).
   renderSlotOverlay?: (index: number, item: CS2EconomyItem) => ReactNode;
   value: NonNullable<CS2BaseInventoryItem["stickers"]>;
 }) {

--- a/app/components/tooltip.tsx
+++ b/app/components/tooltip.tsx
@@ -21,20 +21,6 @@ import {
 import clsx from "clsx";
 import { ReactNode, useState } from "react";
 
-/**
- * Shared hover-tooltip wiring (floating-ui): positioning, the hover/focus/dismiss
- * interactions, and the fade transition. Returns the ref + reference props to spread onto
- * the trigger (a button, image, ...) and a `tooltip` bag to spread onto
- * {@link TooltipBubble}, which renders the floating bubble.
- *
- *     const { getReferenceProps, setReference, tooltip } = useTooltip({ placement: "top" });
- *     return (
- *       <>
- *         <button ref={setReference} {...getReferenceProps()} />
- *         <TooltipBubble {...tooltip}>{label}</TooltipBubble>
- *       </>
- *     );
- */
 export function useTooltip({
   durationMs = 500,
   includeFocus = false,
@@ -42,7 +28,6 @@ export function useTooltip({
   placement = "top"
 }: {
   durationMs?: number;
-  // Also open on keyboard focus — for focusable triggers like buttons.
   includeFocus?: boolean;
   offsetPx?: number;
   placement?: Placement;
@@ -57,7 +42,6 @@ export function useTooltip({
     onOpenChange: setIsOpen,
     open: isOpen,
     placement,
-    // Keep the tooltip on screen as the trigger scrolls/moves.
     whileElementsMounted: autoUpdate
   });
   const hover = useHover(context, { move: false });
@@ -88,10 +72,6 @@ export function useTooltip({
   };
 }
 
-/**
- * The floating bubble for {@link useTooltip}. Spread the hook's `tooltip` bag onto it and
- * pass the label as children; pass `multiline` for pre-formatted multi-line text.
- */
 export function TooltipBubble({
   children,
   floatingStyles,

--- a/app/components/viewer-overlay.tsx
+++ b/app/components/viewer-overlay.tsx
@@ -9,16 +9,6 @@ import { createPortal } from "react-dom";
 import { useOverlayTransition } from "./hooks/use-overlay-transition";
 import { Viewer } from "./viewer";
 
-/**
- * The full-screen shell shared by the 3D sticker flows (apply / scrape / picker): a portal
- * to document.body so the overlay fills the window (escaping any modal's containing block),
- * the viewer iframe behind everything, and the `header` pinned to the top. `children` hold
- * the flow-specific controls.
- *
- * Wrappers stay pointer-events-none so the space around the header/controls passes through
- * to the iframe, keeping the model orbitable; the controls opt back in. Only ever rendered
- * client-side (mounted on user action), so the portal needs no ClientOnly guard.
- */
 export function ViewerOverlay({
   children,
   header,
@@ -45,8 +35,8 @@ export function ViewerOverlay({
       <Viewer
         {...viewerProps}
         className={clsx("size-full border-0 bg-transparent", viewerClassName)}
-        // The app forces `color-scheme: dark`; an iframe whose scheme differs from its
-        // document gets an opaque backdrop. Reset it so the viewer shows through.
+        // An iframe whose color-scheme differs from its document gets an opaque
+        // backdrop; reset it so the viewer shows through.
         style={{ colorScheme: "normal" }}
       />
       <div className="pointer-events-none absolute top-0 left-0 w-full pt-8 text-center">

--- a/app/components/viewer.tsx
+++ b/app/components/viewer.tsx
@@ -17,6 +17,7 @@ export function Viewer({
   apiKey,
   embedUrl,
   cdn,
+  icon,
   item,
   onApi,
   origin,
@@ -26,6 +27,7 @@ export function Viewer({
   apiKey?: string;
   embedUrl?: string;
   cdn?: string;
+  icon?: boolean;
   item?: ViewerItemInput;
   onApi: (api: ViewerApi | undefined) => void;
   origin?: string;
@@ -35,7 +37,7 @@ export function Viewer({
   // a changed `item` prop) don't reload the iframe. Drive later changes through
   // the api, or remount with a `key`.
   const [src] = useState(() =>
-    buildViewerSrc(item, { embedUrl, cdn, key: apiKey })
+    buildViewerSrc(item, { embedUrl, cdn, key: apiKey, icon })
   );
   const onApiRef = useRef(onApi);
   const originRef = useRef(origin);

--- a/app/components/viewer.tsx
+++ b/app/components/viewer.tsx
@@ -7,12 +7,6 @@ import { ComponentPropsWithoutRef, useEffect, useRef, useState } from "react";
 import { buildViewerSrc, ViewerItemInput } from "~/data/viewer";
 import { ViewerApi } from "~/utils/viewer-api";
 
-/**
- * Embeds the CS2 3D viewer iframe and hands its embed API to `onApi` (and
- * `undefined` on unmount). A thin wrapper: the consumer drives the viewer and
- * owns any loading UI via the api's events. Extra props are spread onto the
- * iframe (className, style, allow, ...); `src` is managed internally.
- */
 export function Viewer({
   apiKey,
   embedUrl,
@@ -33,9 +27,9 @@ export function Viewer({
   origin?: string;
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  // `?item=` only seeds the INITIAL state; capture the src once so re-renders (or
-  // a changed `item` prop) don't reload the iframe. Drive later changes through
-  // the api, or remount with a `key`.
+  // `?item=` only seeds the initial state; capture the src once so re-renders
+  // (or a changed `item` prop) don't reload the iframe. Drive later changes
+  // through the api, or remount with a `key`.
   const [src] = useState(() =>
     buildViewerSrc(item, { embedUrl, cdn, key: apiKey, icon })
   );

--- a/app/data/viewer.server.test.ts
+++ b/app/data/viewer.server.test.ts
@@ -13,9 +13,9 @@ const ruleState = vi.hoisted(() => ({
   key: ""
 }));
 vi.mock("~/models/rule.server", () => ({
-  appEnable3dViewer: { get: async () => ruleState.enabled },
+  viewerEnabled: { get: async () => ruleState.enabled },
   steamCallbackUrl: { get: async () => ruleState.callbackUrl },
-  app3dViewerKey: { get: async () => ruleState.key }
+  viewerKey: { get: async () => ruleState.key }
 }));
 
 // The caches are module-level (process-lifetime), so every test gets a fresh module = a cold cache.

--- a/app/data/viewer.server.test.ts
+++ b/app/data/viewer.server.test.ts
@@ -18,7 +18,6 @@ vi.mock("~/models/rule.server", () => ({
   viewerKey: { get: async () => ruleState.key }
 }));
 
-// The caches are module-level (process-lifetime), so every test gets a fresh module = a cold cache.
 async function loadModule() {
   vi.resetModules();
   return await import("./viewer.server");
@@ -43,7 +42,6 @@ describe("resolveViewerCatalog", () => {
       maxId: 10,
       holes: [[2, 3]]
     });
-    // Warm now: served from cache, no second fetch.
     expect(await resolveViewerCatalog()).toEqual({
       maxId: 10,
       holes: [[2, 3]]
@@ -67,7 +65,6 @@ describe("resolveViewerCatalog", () => {
     const cold = resolveViewerCatalog();
     await vi.advanceTimersByTimeAsync(1500);
     expect(await cold).toBeUndefined();
-    // The fetch was never abandoned: once it lands, the next resolve reads the cache.
     settleFetch?.(okJson({ maxId: 5, holes: [] }));
     await vi.advanceTimersByTimeAsync(0);
     expect(await resolveViewerCatalog()).toEqual({ maxId: 5, holes: [] });

--- a/app/data/viewer.server.ts
+++ b/app/data/viewer.server.ts
@@ -5,8 +5,8 @@
 
 import { VIEWER_EMBED_URL } from "~/env.server";
 import {
-  app3dViewerKey,
-  appEnable3dViewer,
+  viewerKey,
+  viewerEnabled,
   steamCallbackUrl
 } from "~/models/rule.server";
 import { DEFAULT_VIEWER_EMBED_URL, ViewerCatalog } from "./viewer";
@@ -43,7 +43,7 @@ function getViewerOrigin() {
 
 // Origins we treat as trusted and therefore exempt from the budget check:
 // local development and our own *.cstrike.app deployments.
-function isTrustedViewerHostname(hostname: string) {
+function isTrustedHostname(hostname: string) {
   return (
     hostname === "localhost" ||
     hostname === "127.0.0.1" ||
@@ -101,7 +101,7 @@ function refreshPeek(domain: string) {
  * remaining request budget (stale-while-revalidate, fail-closed), so the loader
  * never blocks on an external request.
  */
-export function resolveCan3dViewerOrigin({
+export function resolveViewerOriginAllowed({
   enabled,
   hostname,
   key
@@ -113,7 +113,7 @@ export function resolveCan3dViewerOrigin({
   if (!enabled) {
     return false;
   }
-  if (key.trim() !== "" || isTrustedViewerHostname(hostname)) {
+  if (key.trim() !== "" || isTrustedHostname(hostname)) {
     return true;
   }
   const cached = peekCache.get(hostname);
@@ -211,7 +211,7 @@ function refreshViewerCatalog(): Promise<void> {
 /**
  * Resolves the viewer's support manifest — the id envelope the item-aware 3D gate checks against
  * (see isViewerItemSupported). Warm reads are synchronous stale-while-revalidate + fail-closed,
- * mirroring {@link resolveCan3dViewerOrigin}: an expired entry serves stale and refreshes in the
+ * mirroring {@link resolveViewerOriginAllowed}: an expired entry serves stale and refreshes in the
  * background, so a viewer deploy is picked up within the TTL and an unreachable manifest reads as
  * `undefined` (every item unsupported → 2D). Only a COLD cache — a fresh process where no fetch has
  * ever settled, normally just a request that beats the boot warm ({@link warmViewerCaches}) —
@@ -244,15 +244,15 @@ export async function resolveViewerCatalog(): Promise<
  */
 export async function warmViewerCaches() {
   try {
-    const enabled = await appEnable3dViewer.get();
+    const enabled = await viewerEnabled.get();
     if (!enabled) {
       return;
     }
     void refreshViewerCatalog();
-    resolveCan3dViewerOrigin({
+    resolveViewerOriginAllowed({
       enabled,
       hostname: new URL(await steamCallbackUrl.get()).hostname,
-      key: await app3dViewerKey.get()
+      key: await viewerKey.get()
     });
   } catch {}
 }

--- a/app/data/viewer.server.ts
+++ b/app/data/viewer.server.ts
@@ -11,17 +11,11 @@ import {
 } from "~/models/rule.server";
 import { DEFAULT_VIEWER_EMBED_URL, ViewerCatalog } from "./viewer";
 
-// Fraction of the origin's request budget we keep in reserve before offering
-// the 3D viewer to a non-trusted origin.
 const VIEWER_MIN_REMAINING_RATIO = 0.1;
 
-// How long a peek verdict stays warm. The peek never consumes quota, so a short
-// cache keeps us far under the endpoint's own per-IP throttle (≤1 call/min)
-// while staying fresh enough to react to origin exhaustion within the minute.
+// Must stay above the peek endpoint's own per-IP throttle (~1 call/min).
 const VIEWER_PEEK_TTL_MS = 60_000;
 
-// Negative verdict cached after a failed peek (fail closed) — short enough to
-// recover quickly once the viewer is reachable again.
 const VIEWER_PEEK_ERROR_TTL_MS = 30_000;
 
 interface PeekResponse {
@@ -41,8 +35,6 @@ function getViewerOrigin() {
   return new URL(VIEWER_EMBED_URL || DEFAULT_VIEWER_EMBED_URL).origin;
 }
 
-// Origins we treat as trusted and therefore exempt from the budget check:
-// local development and our own *.cstrike.app deployments.
 function isTrustedHostname(hostname: string) {
   return (
     hostname === "localhost" ||
@@ -62,7 +54,6 @@ async function peekOriginAllowed(domain: string) {
     return false;
   }
   const { limit, remaining } = (await response.json()) as PeekResponse;
-  // No reported limit means unlimited budget; otherwise keep the reserve buffer.
   if (remaining === null || limit === null) {
     return true;
   }
@@ -74,8 +65,6 @@ function refreshPeek(domain: string) {
     return;
   }
   peekInFlight.add(domain);
-  // Fail closed: any error caches a negative verdict so we neither hammer the
-  // endpoint nor optimistically show a viewer we can't back.
   peekOriginAllowed(domain)
     .then((verdict) => {
       peekCache.set(domain, {
@@ -94,13 +83,6 @@ function refreshPeek(domain: string) {
     });
 }
 
-/**
- * Resolves, synchronously, whether the 3D viewer should be offered for this app
- * instance's origin. Disabled and trusted instances answer with no network at
- * all; other origins are gated by a cached, background-refreshed peek of the
- * remaining request budget (stale-while-revalidate, fail-closed), so the loader
- * never blocks on an external request.
- */
 export function resolveViewerOriginAllowed({
   enabled,
   hostname,
@@ -123,33 +105,20 @@ export function resolveViewerOriginAllowed({
   return cached?.verdict ?? false;
 }
 
-// --- Viewer support manifest (#17) -------------------------------------------------------------
-
-// How long a fetched catalog stays warm before a background refresh. The renderable set only changes
-// on a viewer deploy, so this is long; a refresh (or any host page reload, which re-runs the loader)
-// picks up a deploy within the window without an app restart.
 const VIEWER_CATALOG_TTL_MS = 300_000;
 
-// Negative verdict cached after a failed fetch (fail-closed) — short, so 3D returns quickly once the
-// endpoint is reachable again.
 const VIEWER_CATALOG_ERROR_TTL_MS = 30_000;
 
-// Bounds how long a COLD resolve (fresh process, no fetch has ever settled) waits for the in-flight
-// catalog fetch before failing closed for this request. Without it the first session after every
-// deploy/restart would be all-2D: the loader would ship `viewerCatalog: undefined` and never
-// revalidate mid-session. The boot warm (warmViewerCaches) makes hitting this rare — only a request
-// that beats it pays — and the fetch keeps running regardless, so a timed-out request reads as 2D
-// and the next one hits the cache.
+// How long a cold resolve (no fetch has ever settled) waits before failing
+// closed; without a bounded wait, the first session after a deploy would ship
+// no catalog (all-2D) and never revalidate mid-session.
 const VIEWER_CATALOG_COLD_WAIT_MS = 1500;
 
 interface CatalogCacheEntry {
   expiresAt: number;
-  // undefined = the fetch failed/was malformed; the gate treats it as "nothing supported" (2D).
   catalog: ViewerCatalog | undefined;
 }
 
-// A single global entry (the manifest isn't per-embedder, unlike the origin peek). Module-level =
-// process-lifetime, refreshed in the background (stale-while-revalidate).
 let catalogCache: CatalogCacheEntry | undefined;
 let catalogInFlight: Promise<void> | undefined;
 
@@ -166,7 +135,6 @@ async function fetchViewerCatalog(): Promise<ViewerCatalog | undefined> {
   ) {
     return undefined;
   }
-  // Keep only well-formed [lo, hi] pairs; drop anything malformed rather than trust it.
   const holes = data.holes.filter(
     (range): range is [number, number] =>
       Array.isArray(range) &&
@@ -177,14 +145,10 @@ async function fetchViewerCatalog(): Promise<ViewerCatalog | undefined> {
   return { maxId: data.maxId, holes };
 }
 
-// Kicks (or joins) the background catalog fetch and returns its promise, so a cold resolve can
-// bound-await the very first verdict.
 function refreshViewerCatalog(): Promise<void> {
   if (catalogInFlight !== undefined) {
     return catalogInFlight;
   }
-  // Fail closed: any error caches an undefined verdict (short TTL) so the gate stays on 2D rather
-  // than optimistically offering a viewer we can't vouch for.
   catalogInFlight = fetchViewerCatalog()
     .then((catalog) => {
       catalogCache = {
@@ -208,15 +172,6 @@ function refreshViewerCatalog(): Promise<void> {
   return catalogInFlight;
 }
 
-/**
- * Resolves the viewer's support manifest — the id envelope the item-aware 3D gate checks against
- * (see isViewerItemSupported). Warm reads are synchronous stale-while-revalidate + fail-closed,
- * mirroring {@link resolveViewerOriginAllowed}: an expired entry serves stale and refreshes in the
- * background, so a viewer deploy is picked up within the TTL and an unreachable manifest reads as
- * `undefined` (every item unsupported → 2D). Only a COLD cache — a fresh process where no fetch has
- * ever settled, normally just a request that beats the boot warm ({@link warmViewerCaches}) —
- * awaits the fetch, bounded by VIEWER_CATALOG_COLD_WAIT_MS so a hung viewer can't stall first paint.
- */
 export async function resolveViewerCatalog(): Promise<
   ViewerCatalog | undefined
 > {
@@ -234,14 +189,6 @@ export async function resolveViewerCatalog(): Promise<
   return catalogCache?.catalog;
 }
 
-/**
- * Fires the viewer fetches once at boot (entry.server, after rules are ready) so the first request
- * after a deploy/restart doesn't fail closed to 2D on cold caches: the catalog manifest always, and
- * the origin rate-limit peek when the origin actually needs one (trusted/keyed origins resolve with
- * no network). Best-effort fire-and-forget — a failed warm must not take the boot down; both caches
- * are stale-while-revalidate and fail-closed on their own, so the first request just pays the
- * bounded cold wait instead.
- */
 export async function warmViewerCaches() {
   try {
     const enabled = await viewerEnabled.get();

--- a/app/data/viewer.test.ts
+++ b/app/data/viewer.test.ts
@@ -11,7 +11,7 @@ import {
   isViewerIdSupported,
   isViewerItemSupported,
   toViewerItem,
-  viewerItemIds
+  getViewerItemIds
 } from "./viewer";
 
 // A small manifest: max renderable id 100, with two removed/never-assigned ranges below it.
@@ -67,15 +67,15 @@ describe("isViewerIdSupported", () => {
   });
 });
 
-describe("viewerItemIds", () => {
+describe("getViewerItemIds", () => {
   it("returns the weapon id plus every applied sticker id", () => {
     expect(
-      viewerItemIds({ id: 7, stickers: { "0": { id: 30 }, "2": { id: 40 } } })
+      getViewerItemIds({ id: 7, stickers: { "0": { id: 30 }, "2": { id: 40 } } })
     ).toEqual([7, 30, 40]);
   });
 
   it("returns just the weapon id when there are no stickers", () => {
-    expect(viewerItemIds({ id: 7 })).toEqual([7]);
+    expect(getViewerItemIds({ id: 7 })).toEqual([7]);
   });
 });
 

--- a/app/data/viewer.test.ts
+++ b/app/data/viewer.test.ts
@@ -179,6 +179,17 @@ describe("buildViewerSrc", () => {
     expect(new URL(buildViewerSrc()).searchParams.has("item")).toBe(false);
   });
 
+  it("sets ?icon= only when icon mode is requested", () => {
+    expect(
+      new URL(buildViewerSrc({ id: 7 }, { icon: true })).searchParams.has(
+        "icon"
+      )
+    ).toBe(true);
+    expect(new URL(buildViewerSrc({ id: 7 })).searchParams.has("icon")).toBe(
+      false
+    );
+  });
+
   it("always opts in to half-degree rotation", () => {
     expect(new URL(buildViewerSrc()).searchParams.get("halfRotation")).toBe(
       "1"

--- a/app/data/viewer.test.ts
+++ b/app/data/viewer.test.ts
@@ -14,7 +14,6 @@ import {
   getViewerItemIds
 } from "./viewer";
 
-// A small manifest: max renderable id 100, with two removed/never-assigned ranges below it.
 const catalog = {
   maxId: 100,
   holes: [
@@ -23,9 +22,6 @@ const catalog = {
   ] as [number, number][]
 };
 
-// The fabricated economy backing the kind gate — ids line up with the catalog above. Loaded
-// without a language map, so names default to String(id). Id 70 is deliberately absent
-// (fail-closed path).
 CS2Economy.load({
   items: [
     { id: 5, type: CS2ItemType.Weapon, rarity: CS2RarityColor.Common },
@@ -42,7 +38,6 @@ CS2Economy.load({
 
 describe("isViewerIdSupported", () => {
   it("fails closed when the manifest is absent", () => {
-    // No manifest (endpoint down / not yet fetched) => nothing is offered in 3D.
     expect(isViewerIdSupported(undefined, 5)).toBe(false);
   });
 
@@ -61,7 +56,6 @@ describe("isViewerIdSupported", () => {
     expect(isViewerIdSupported(catalog, 11)).toBe(false);
     expect(isViewerIdSupported(catalog, 12)).toBe(false);
     expect(isViewerIdSupported(catalog, 20)).toBe(false);
-    // Just outside the holes.
     expect(isViewerIdSupported(catalog, 9)).toBe(true);
     expect(isViewerIdSupported(catalog, 21)).toBe(true);
   });
@@ -70,7 +64,10 @@ describe("isViewerIdSupported", () => {
 describe("getViewerItemIds", () => {
   it("returns the weapon id plus every applied sticker id", () => {
     expect(
-      getViewerItemIds({ id: 7, stickers: { "0": { id: 30 }, "2": { id: 40 } } })
+      getViewerItemIds({
+        id: 7,
+        stickers: { "0": { id: 30 }, "2": { id: 40 } }
+      })
     ).toEqual([7, 30, 40]);
   });
 
@@ -108,11 +105,9 @@ describe("isViewerItemSupported", () => {
     expect(
       isViewerItemSupported(catalog, { id: 5, stickers: { "0": { id: 50 } } })
     ).toBe(true);
-    // A sticker beyond maxId blocks the whole item (edit falls back to 2D).
     expect(
       isViewerItemSupported(catalog, { id: 5, stickers: { "0": { id: 200 } } })
     ).toBe(false);
-    // The weapon itself sitting in a hole blocks it.
     expect(isViewerItemSupported(catalog, { id: 11 })).toBe(false);
   });
 
@@ -123,7 +118,6 @@ describe("isViewerItemSupported", () => {
   it("only offers kinds the viewer renders (weapon/melee/sticker)", () => {
     expect(isViewerItemSupported(catalog, { id: 63 })).toBe(true);
     expect(isViewerItemSupported(catalog, { id: 64 })).toBe(true);
-    // Inside the envelope, but a kind the viewer never renders -> 2D.
     expect(isViewerItemSupported(catalog, { id: 60 })).toBe(false);
     expect(isViewerItemSupported(catalog, { id: 61 })).toBe(false);
     expect(isViewerItemSupported(catalog, { id: 62 })).toBe(false);

--- a/app/data/viewer.ts
+++ b/app/data/viewer.ts
@@ -9,43 +9,31 @@ import {
   CS2EconomyItem,
   CS2InventoryItem
 } from "@ianlucas/cs2-lib";
-// Type-only (erased) so this module never depends on viewer-api at runtime.
+// Type-only so this module never depends on viewer-api at runtime (it is also
+// imported server-side).
 import type { ViewerItem } from "~/utils/viewer-api";
 
-// The public embed URL of the hosted CS2 3D viewer (its `/view` page). Overridable
-// per-deployment via the VIEWER_EMBED_URL env var (root loader → `viewerEmbedUrl`
-// rule → the viewer component's `embedUrl` client-side, and getViewerOrigin
-// server-side) for self-hosting the viewer; this is the fallback when it is unset.
 export const DEFAULT_VIEWER_EMBED_URL = "https://3d.cstrike.app/view";
 
-// Anything we can turn into a viewer item: an economy entry, a live inventory
-// item, or the plain serialized shape.
 export type ViewerItemInput =
   CS2EconomyItem | CS2InventoryItem | CS2BaseInventoryItem;
 
-// The viewer's support manifest (its `/api/catalog`): the max economy id it can render plus the id
-// gaps below it. `supported(id) = id <= maxId && id not in holes`. Encodes the complement of the
-// viewer's ~12k renderable ids in ~60 bytes, which works because cs2-lib ids are stable + append-only
-// (id N is the same item in every version), so the host can compare its OWN ids against this envelope.
-// The envelope carries no KIND information — non-renderable kinds are interleaved "present" ids — so
-// it only answers for ids the host already classified as renderable (isViewerRenderableKind).
-// Resolved server-side (viewer.server.ts) and injected into rules; read synchronously by the gate.
+// The viewer's `/api/catalog` manifest: supported(id) = id <= maxId && id not
+// inside a [lo, hi] hole. Carries no kind information (non-renderable kinds sit
+// interleaved as "present" ids), so it only answers for ids the host already
+// classified as renderable via isViewerRenderableKind.
 export interface ViewerCatalog {
   maxId: number;
   holes: [number, number][];
 }
 
-// The manifest as the gate READS it. Structural + loose on `holes` so it accepts both the server's
-// exact `[number, number][]` and the loader-serialized form (SerializeFrom may widen the inner tuples
-// to `number[]`). ViewerCatalog is assignable to this.
+// Loose on `holes` because the loader-serialized form (SerializeFrom) may widen
+// the tuples to `number[]`.
 export type ViewerCatalogLike = {
   maxId: number;
   holes: readonly (readonly number[])[];
 };
 
-// Whether the viewer can render economy id `id`, per its manifest. Fail-closed: an absent manifest
-// (endpoint down / not yet fetched) reads as unsupported, so the host never offers a 3D viewer it
-// can't back — the item-aware gate then keeps that item on the 2D editor.
 export function isViewerIdSupported(
   catalog: ViewerCatalogLike | undefined,
   id: number
@@ -61,9 +49,6 @@ export function isViewerIdSupported(
   return true;
 }
 
-// Every economy id the viewer must render for `item`: its weapon/base id plus each applied sticker's
-// id. The gate requires ALL of them to be supported before it offers 3D (a weapon with a
-// viewer-unknown sticker falls back to 2D).
 export function getViewerItemIds(item: ViewerItemInput): number[] {
   const viewerItem = toViewerItem(item);
   const ids = [viewerItem.id];
@@ -77,10 +62,6 @@ export function getViewerItemIds(item: ViewerItemInput): number[] {
   return ids;
 }
 
-// The kinds the viewer renders — exactly the set its client/economy.ts offers. The manifest
-// deliberately encodes only the id ENVELOPE: non-renderable kinds (music kits, collectibles,
-// agents, ...) sit interleaved as "present" ids in it, so classifying kind is the host's half of
-// the catalog contract. Fail-closed: an id the loaded economy doesn't know reads as unsupported.
 function isViewerRenderableKind(item: ViewerItemInput): boolean {
   const economyItem =
     item instanceof CS2EconomyItem ? item : CS2Economy.items.get(item.id);
@@ -90,8 +71,6 @@ function isViewerRenderableKind(item: ViewerItemInput): boolean {
   );
 }
 
-// Whether the viewer can render `item` in full — a renderable kind (weapon/melee/sticker) whose
-// body and every applied sticker sit inside the catalog envelope.
 export function isViewerItemSupported(
   catalog: ViewerCatalogLike | undefined,
   item: ViewerItemInput
@@ -102,9 +81,6 @@ export function isViewerItemSupported(
   );
 }
 
-// Narrow any accepted item into the subset the viewer reads (id/seed/wear/
-// stickers/statTrak/nameTag), dropping undefined fields so the viewer overlays
-// its own defaults.
 export function toViewerItem(item: ViewerItemInput): ViewerItem {
   if (item instanceof CS2InventoryItem) {
     return toViewerItem(item.asBase());
@@ -121,10 +97,6 @@ export function toViewerItem(item: ViewerItemInput): ViewerItem {
   return viewerItem;
 }
 
-// Build the iframe `src`: the viewer URL with the initial state encoded as the
-// `?item=` JSON param (the embed API takes over after load). `key`/`cdn`/`icon` map
-// to the viewer's other query params; `cdn` points the viewer at a self-hosted mirror
-// of its economy asset tree (weapon models, textures, sticker masks, model-data).
 export function buildViewerSrc(
   item?: ViewerItemInput,
   options?: { embedUrl?: string; cdn?: string; key?: string; icon?: boolean }

--- a/app/data/viewer.ts
+++ b/app/data/viewer.ts
@@ -64,7 +64,7 @@ export function isViewerIdSupported(
 // Every economy id the viewer must render for `item`: its weapon/base id plus each applied sticker's
 // id. The gate requires ALL of them to be supported before it offers 3D (a weapon with a
 // viewer-unknown sticker falls back to 2D).
-export function viewerItemIds(item: ViewerItemInput): number[] {
+export function getViewerItemIds(item: ViewerItemInput): number[] {
   const viewerItem = toViewerItem(item);
   const ids = [viewerItem.id];
   if (viewerItem.stickers !== undefined) {
@@ -98,7 +98,7 @@ export function isViewerItemSupported(
 ): boolean {
   return (
     isViewerRenderableKind(item) &&
-    viewerItemIds(item).every((id) => isViewerIdSupported(catalog, id))
+    getViewerItemIds(item).every((id) => isViewerIdSupported(catalog, id))
   );
 }
 

--- a/app/models/rule.server.ts
+++ b/app/models/rule.server.ts
@@ -597,14 +597,14 @@ export const appHideAuth = new Rule({
   defaultValue: false
 });
 
-export const appEnable3dViewer = new Rule({
-  name: "appEnable3dViewer",
+export const viewerEnabled = new Rule({
+  name: "viewerEnabled",
   type: "boolean",
   defaultValue: false
 });
 
-export const app3dViewerKey = new Rule({
-  name: "app3dViewerKey",
+export const viewerKey = new Rule({
+  name: "viewerKey",
   type: "string",
   defaultValue: VIEWER_KEY ?? ""
 });

--- a/app/models/rule.server.ts
+++ b/app/models/rule.server.ts
@@ -603,6 +603,12 @@ export const viewerEnabled = new Rule({
   defaultValue: false
 });
 
+export const viewerAttachmentsOnly = new Rule({
+  name: "viewerAttachmentsOnly",
+  type: "boolean",
+  defaultValue: false
+});
+
 export const viewerKey = new Rule({
   name: "viewerKey",
   type: "string",

--- a/app/models/rule.ts
+++ b/app/models/rule.ts
@@ -4,9 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import {
-  app3dViewerKey,
   appCacheInventory,
-  appEnable3dViewer,
   appFaviconMimeType,
   appFaviconUrl,
   appFooterName,
@@ -73,6 +71,8 @@ import {
   inventoryItemEquipHideType,
   inventoryMaxItems,
   inventoryStorageUnitMaxItems,
+  viewerEnabled,
+  viewerKey,
   Rule
 } from "./rule.server";
 
@@ -101,9 +101,7 @@ export async function getRules<T extends Record<string, Rule<string, unknown>>>(
 export async function getClientRules(userId?: string) {
   return await getRules(
     {
-      app3dViewerKey,
       appCacheInventory,
-      appEnable3dViewer,
       appFaviconMimeType,
       appFaviconUrl,
       appFooterName,
@@ -169,7 +167,9 @@ export async function getClientRules(userId?: string) {
       inventoryItemEquipHideModel,
       inventoryItemEquipHideType,
       inventoryMaxItems,
-      inventoryStorageUnitMaxItems
+      inventoryStorageUnitMaxItems,
+      viewerEnabled,
+      viewerKey
     },
     userId
   );

--- a/app/models/rule.ts
+++ b/app/models/rule.ts
@@ -71,6 +71,7 @@ import {
   inventoryItemEquipHideType,
   inventoryMaxItems,
   inventoryStorageUnitMaxItems,
+  viewerAttachmentsOnly,
   viewerEnabled,
   viewerKey,
   Rule
@@ -168,6 +169,7 @@ export async function getClientRules(userId?: string) {
       inventoryItemEquipHideType,
       inventoryMaxItems,
       inventoryStorageUnitMaxItems,
+      viewerAttachmentsOnly,
       viewerEnabled,
       viewerKey
     },

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -102,8 +102,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
         hostname: new URL(appUrl).hostname,
         key: clientRules.viewerKey
       }),
-      // The viewer's support manifest, for the item-aware 3D gate. Resolved only when 3D is enabled
-      // (skip the fetch otherwise); undefined leaves the gate fail-closed on 2D.
       viewerCatalog: clientRules.viewerEnabled
         ? await resolveViewerCatalog()
         : undefined,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -40,7 +40,7 @@ import {
   VIEWER_EMBED_URL
 } from "./env.server";
 import {
-  resolveCan3dViewerOrigin,
+  resolveViewerOriginAllowed,
   resolveViewerCatalog
 } from "./data/viewer.server";
 import { middleware } from "./middleware.server";
@@ -97,14 +97,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
       viewerAssetsBaseUrl: nonEmptyString(VIEWER_ASSETS_BASE_URL),
       cloudflareAnalyticsToken: CLOUDFLARE_ANALYTICS_TOKEN,
       sourceCommit: SOURCE_COMMIT,
-      can3dViewerOrigin: resolveCan3dViewerOrigin({
-        enabled: clientRules.appEnable3dViewer,
+      viewerOriginAllowed: resolveViewerOriginAllowed({
+        enabled: clientRules.viewerEnabled,
         hostname: new URL(appUrl).hostname,
-        key: clientRules.app3dViewerKey
+        key: clientRules.viewerKey
       }),
       // The viewer's support manifest, for the item-aware 3D gate. Resolved only when 3D is enabled
       // (skip the fetch otherwise); undefined leaves the gate fail-closed on 2D.
-      viewerCatalog: clientRules.appEnable3dViewer
+      viewerCatalog: clientRules.viewerEnabled
         ? await resolveViewerCatalog()
         : undefined,
       meta: { appUrl, appSiteName }

--- a/app/routes/api.action.sync._index.tsx
+++ b/app/routes/api.action.sync._index.tsx
@@ -80,9 +80,6 @@ import {
 } from "~/utils/shapes.server";
 import type { Route } from "./+types/api.action.sync._index";
 
-// Placement carried by the sticker-apply actions (applied weapon + free-item add).
-// `schema` is the markup anchor; `x`/`y`/`rotation`/`wear` reuse the shared sticker
-// fields. cs2-lib re-validates each against the target model before mutating.
 const stickerPlacementShape = {
   schema: nonNegativeInt,
   x: optionalStickerOffset,

--- a/app/routes/settings._index.tsx
+++ b/app/routes/settings._index.tsx
@@ -49,7 +49,7 @@ export default function Settings() {
     prefer2dStickerEditor: selectedPrefer2dStickerEditor,
     statsForNerds: selectedStatsForNerds
   } = usePreferences();
-  const { appEnable3dViewer } = useRules();
+  const { viewerEnabled } = useRules();
   const [inventory, setInventory] = useInventory();
   const translate = useTranslate();
   const sync = useSync();
@@ -158,7 +158,7 @@ export default function Settings() {
             onChange={setHideNewItemLabel}
           />
         </SettingsLabel>
-        {appEnable3dViewer && (
+        {viewerEnabled && (
           <SettingsLabel label={translate("SettingsPrefer2dStickerEditor")}>
             <EditorToggle
               checked={prefer2dStickerEditor}

--- a/app/utils/economy.ts
+++ b/app/utils/economy.ts
@@ -66,26 +66,18 @@ export function isItemCountable(item: CS2EconomyItem) {
 export const baseStickerSlabId = 15200;
 export const newItemStartingId = 26817;
 export const newItemEndAt = 1784841228427;
-// Keychain offsets keep the app's own flat range: the lib publishes no keychain
-// offset bounds (its validator still only checks finiteness), so the app owns it.
 export const minKeychainOffset = -100;
 export const maxKeychainOffset = 100;
 export const keychainOffsetFactor = 0.001;
 export const seedStringMaxLen = String(CS2_MAX_SEED).length;
 export const wearStringMaxLen = String(CS2_WEAR_FACTOR).length;
 export const stickerWearStringMaxLen = String(CS2_STICKER_WEAR_FACTOR).length;
-// Sticker offsets follow the lib's per-model envelope (bounds come from the
-// economy item); only the precision grid is fixed here. Every published bound is
-// sub-unit, so the input width is sign + "0." + the grid's decimals.
 const stickerOffsetDecimalPlaces = countDecimals(CS2_STICKER_OFFSET_FACTOR);
 export const stickerOffsetStringMaxLen =
   "-0.".length + stickerOffsetDecimalPlaces;
 const keychainOffsetDecimalPlaces = countDecimals(keychainOffsetFactor);
 export const keychainOffsetStringMaxLen =
   String(maxKeychainOffset).length + 1 + keychainOffsetDecimalPlaces;
-// v8 uses a signed [-180, 180] range on cs2-lib's half-degree grid; the longest
-// input is the negative bound's half step ("-179.5" = 6 chars), so size the max
-// length off the minimum plus the ".5" suffix.
 export const stickerRotationStringMaxLen =
   String(CS2_MIN_STICKER_ROTATION).length + ".5".length;
 
@@ -109,8 +101,6 @@ export function stickerOffsetToString(offset: number) {
   return offset.toFixed(stickerOffsetDecimalPlaces);
 }
 
-// Bounds are the model's published envelope (`getMinimum/MaximumStickerOffset*`),
-// passed in by the editor; `CS2Inventory` is the authoritative gate downstream.
 export function validateStickerOffset(
   offset: number,
   min: number | undefined,

--- a/app/utils/shapes.ts
+++ b/app/utils/shapes.ts
@@ -17,12 +17,6 @@ export const nonNegativeInt = z.number().int().nonnegative().finite().safe();
 export const positiveInt = z.number().int().positive().finite().safe();
 export const nonNegativeFloat = z.number().nonnegative().finite();
 
-// A sticker placement's offset (x/y), rotation, and wear — each optional and
-// self-validating against the economy rules. Shared by the stored-inventory shape
-// below and the sync action shape (`~/routes/api.action.sync`) so the two never drift
-// on what a valid placement is. Offsets and rotation are signed (the sticker moves
-// either way and rotates to negative angles), so the base is a plain finite number —
-// NOT `positiveInt`, which would wrongly reject negatives, zero, and fractions.
 export const optionalStickerOffset = z
   .number()
   .finite()

--- a/app/utils/viewer-api.ts
+++ b/app/utils/viewer-api.ts
@@ -44,6 +44,7 @@ export interface ViewerEventMap {
   ready: { v: number };
   change: ViewerState;
   loading: { busy: boolean };
+  rendered: { item: ViewerItem };
   rateLimited: { retryAfterMs: number; scope?: RateLimitScope };
   unsupported: { reason: ViewerUnsupportedReason };
 }
@@ -361,6 +362,9 @@ export class ViewerApi extends EventTarget {
       }
       case "loading":
         this.dispatch("loading", data as ViewerEventMap["loading"]);
+        break;
+      case "rendered":
+        this.dispatch("rendered", data as ViewerEventMap["rendered"]);
         break;
       case "rateLimited":
         this.dispatch("rateLimited", data as ViewerEventMap["rateLimited"]);

--- a/app/utils/viewer-api.ts
+++ b/app/utils/viewer-api.ts
@@ -262,7 +262,26 @@ export class ViewerApi extends EventTarget {
     }
   }
 
+  private canReachViewer(): boolean {
+    const contentWindow = this.iframe.contentWindow;
+    if (contentWindow === null) {
+      return false;
+    }
+    if (this.origin === window.location.origin) {
+      return true;
+    }
+    try {
+      void contentWindow.location.href;
+      return false;
+    } catch {
+      return true;
+    }
+  }
+
   private post(envelope: Envelope): void {
+    if (!this.canReachViewer()) {
+      return;
+    }
     this.iframe.contentWindow?.postMessage(envelope, this.origin);
   }
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -91,20 +91,6 @@ Hide the logo in the app.
 
 Hide authentication controls in the app.
 
-### `appEnable3dViewer`
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Enable the 3D viewer (e.g. the craft sticker editor). Still gated by a reachable viewer and available rate-limit budget.
-
-### `app3dViewerKey`
-
-- **Type:** `string`
-- **Default:** `VIEWER_KEY` env var or _empty_
-
-Partner key for the 3D viewer. Sent as the iframe `key` and used as a trusted-partner signal that skips the rate-limit check.
-
 ## Steam
 
 > [!CAUTION]  
@@ -546,6 +532,22 @@ CSFloat API URL for item inspection integration.
 - **Default:** _empty_
 
 CSFloat API request headers. Example: `Authorization;Bearer MyAPIToken`.
+
+## Viewer
+
+### `viewerEnabled`
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Enable the 3D viewer (e.g. the craft sticker editor). Still gated by a reachable viewer and available rate-limit budget.
+
+### `viewerKey`
+
+- **Type:** `string`
+- **Default:** `VIEWER_KEY` env var or _empty_
+
+Partner key for the 3D viewer. Sent as the iframe `key` and used as a trusted-partner signal that skips the rate-limit check.
 
 ## Rule overwriting
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -542,6 +542,13 @@ CSFloat API request headers. Example: `Authorization;Bearer MyAPIToken`.
 
 Enable the 3D viewer (e.g. the craft sticker editor). Still gated by a reachable viewer and available rate-limit budget.
 
+### `viewerAttachmentsOnly`
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Restrict the 3D viewer to attachment features (applying, scraping, and positioning stickers - and keychains in the future). Item inspection and the craft item preview fall back to 2D images. Has no effect when `viewerEnabled` is `false`.
+
 ### `viewerKey`
 
 - **Type:** `string`

--- a/prisma/migrations/20260713190257_rename_viewer_rules/migration.sql
+++ b/prisma/migrations/20260713190257_rename_viewer_rules/migration.sql
@@ -1,0 +1,9 @@
+-- Rename viewer rules to the top-level `viewer*` domain. Overrides in
+-- "UserRule"/"GroupRule" follow via ON UPDATE CASCADE. If the app booted with
+-- the new names before migrating, `register()` has already inserted fresh
+-- default rows under them; drop those so the old rows (the operator's actual
+-- values and overrides) win the rename.
+DELETE FROM "Rule" WHERE name = 'viewerEnabled' AND EXISTS (SELECT 1 FROM "Rule" WHERE name = 'appEnable3dViewer');
+UPDATE "Rule" SET name = 'viewerEnabled' WHERE name = 'appEnable3dViewer';
+DELETE FROM "Rule" WHERE name = 'viewerKey' AND EXISTS (SELECT 1 FROM "Rule" WHERE name = 'app3dViewerKey');
+UPDATE "Rule" SET name = 'viewerKey' WHERE name = 'app3dViewerKey';


### PR DESCRIPTION
- **Add live 3D icon preview to the item editor**
- **Crossfade the editor preview from image to 3D once rendered**
- **Unify 3D viewer naming under the viewer domain**
- **Strip redundant comments from the viewer work**
