### PR TITLE
Rework Graffiti system

### DIFF
--- a/app/components/hooks/use-name-item.test.ts
+++ b/app/components/hooks/use-name-item.test.ts
@@ -15,7 +15,8 @@ CS2Economy.load({
   language: english
 });
 
-const translate = () => "statTrak™";
+const translate = (token: string) =>
+  token === "ItemSealedGraffiti" ? "Sealed Graffiti" : "statTrak™";
 const nameItem = nameItemFactory(translate);
 const nameItemString = (...args: Parameters<typeof nameItem>) =>
   nameItem(...args)
@@ -86,7 +87,7 @@ describe("test useNameItem hook", () => {
       "Music Kit",
       "Austin Wintory, Desert Fire"
     ]);
-    expect(nameItem(GRAFFITI_EZ_ITEM)).toEqual(["Graffiti", "EZ"]);
+    expect(nameItem(GRAFFITI_EZ_ITEM)).toEqual(["Sealed Graffiti", "EZ"]);
     expect(nameItem(COLLECTIBLE_ALYX_PIN_ITEM)).toEqual(["Alyx Pin", ""]);
     expect(nameItem(CONTAINER_KILOWATT_CASE_ITEM)).toEqual([
       "Kilowatt Case",
@@ -195,7 +196,7 @@ describe("test useNameItem hook", () => {
       "Austin Wintory, Desert Fire"
     ]);
     expect(nameItem(GRAFFITI_EZ_ITEM, "editor-name")).toEqual([
-      "Graffiti",
+      "Sealed Graffiti",
       "EZ"
     ]);
     expect(nameItem(COLLECTIBLE_ALYX_PIN_ITEM, "editor-name")).toEqual([
@@ -286,7 +287,7 @@ describe("test useNameItem hook", () => {
       "Austin Wintory, Desert Fire"
     ]);
     expect(nameItem(GRAFFITI_EZ_ITEM, "inventory-name")).toEqual([
-      "Graffiti",
+      "Sealed Graffiti",
       "EZ"
     ]);
     expect(nameItem(COLLECTIBLE_ALYX_PIN_ITEM, "inventory-name")).toEqual([

--- a/app/components/hooks/use-name-item.ts
+++ b/app/components/hooks/use-name-item.ts
@@ -45,6 +45,13 @@ export function nameItemFactory(translate: ReturnType<typeof useTranslate>) {
     let [model, ...names] = item.name.split("|").map((s) => s.trim());
     let name = names.join(" | ");
     model = `${quality}${statTrak}${model}`;
+    if (
+      item.isGraffiti() &&
+      item.hasCharges() &&
+      inventoryItem?.isSealed() === true
+    ) {
+      model = translate("ItemSealedGraffiti");
+    }
     if (item.isAgent()) {
       [model, name] = name.split(" | ");
     } else if (ITEM_TYPES_WITHOUT_NAME.includes(item.type)) {

--- a/app/components/hooks/use-name-item.ts
+++ b/app/components/hooks/use-name-item.ts
@@ -48,7 +48,7 @@ export function nameItemFactory(translate: ReturnType<typeof useTranslate>) {
     if (
       item.isGraffiti() &&
       item.hasCharges() &&
-      inventoryItem?.isSealed() === true
+      (inventoryItem === undefined || inventoryItem.isSealed())
     ) {
       model = translate("ItemSealedGraffiti");
     }

--- a/app/components/hooks/use-unseal-graffiti.ts
+++ b/app/components/hooks/use-unseal-graffiti.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Ian Lucas. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { useState } from "react";
+
+export function useUnsealGraffiti() {
+  const [unsealGraffiti, setUnsealGraffiti] = useState<{
+    uid: number;
+  }>();
+
+  function handleUnsealGraffiti(uid: number) {
+    return setUnsealGraffiti({ uid });
+  }
+
+  function closeUnsealGraffiti() {
+    return setUnsealGraffiti(undefined);
+  }
+
+  function isUnsealingGraffiti(
+    state: typeof unsealGraffiti
+  ): state is NonNullable<typeof unsealGraffiti> {
+    return state !== undefined;
+  }
+
+  return {
+    closeUnsealGraffiti,
+    handleUnsealGraffiti,
+    isUnsealingGraffiti,
+    unsealGraffiti
+  };
+}

--- a/app/components/inspect-item.tsx
+++ b/app/components/inspect-item.tsx
@@ -165,10 +165,11 @@ function InspectItemShareButton({ item }: { item: CS2InventoryItem }) {
 
 function InspectItemDescription({ item }: { item: CS2InventoryItem }) {
   const translate = useTranslate();
-  const isSealedGraffiti =
-    item.isGraffiti() && item.hasCharges() && item.isSealed();
+  const isGraffitiWithCharges = item.isGraffiti() && item.hasCharges();
+  const isSealedGraffiti = isGraffitiWithCharges && item.isSealed();
+  const isUnsealedGraffiti = isGraffitiWithCharges && !item.isSealed();
   if (
-    !isSealedGraffiti &&
+    !isGraffitiWithCharges &&
     (item.parent ?? item).description === undefined &&
     item.description === undefined
   ) {
@@ -180,6 +181,16 @@ function InspectItemDescription({ item }: { item: CS2InventoryItem }) {
         <p className="mt-4 whitespace-pre-wrap text-neutral-300">
           {translate("ItemSealedGraffitiDesc")}
         </p>
+      ) : isUnsealedGraffiti ? (
+        <>
+          <ItemDescription item={item} />
+          <p className="mt-4 text-cyan-200/80">
+            {translate(
+              "ItemGraffitiChargesRemaining",
+              String(item.getCharges())
+            )}
+          </p>
+        </>
       ) : (
         <ItemDescription item={item} />
       )}

--- a/app/components/inspect-item.tsx
+++ b/app/components/inspect-item.tsx
@@ -23,17 +23,18 @@ import { useTimedState } from "./hooks/use-timed-state";
 import { useViewer } from "./hooks/use-viewer";
 import { useViewerAvailability } from "./hooks/use-viewer-availability";
 import { useViewerStatus } from "./hooks/use-viewer-status";
+import { InGameOverlay } from "./in-game-overlay";
 import { InfoIcon } from "./info-icon";
 import { InspectCharmDetachments } from "./inspect-charm-detachments";
 import { ItemDescription } from "./item-description";
 import { ItemImage } from "./item-image";
 import { ModalButton } from "./modal-button";
-import { Overlay } from "./overlay";
 import { UseItemFooter } from "./use-item-footer";
 import { ViewerOverlay } from "./viewer-overlay";
 
 interface InspectItemProps {
   onClose: () => void;
+  onUnsealGraffiti?: (uid: number) => void;
   uid: number;
 }
 
@@ -186,7 +187,27 @@ function InspectItemDescription({ item }: { item: CS2InventoryItem }) {
   );
 }
 
-function InspectItem3d({ onClose, uid }: InspectItemProps) {
+function InspectItemUnsealButton({
+  item,
+  onClick
+}: {
+  item: CS2InventoryItem;
+  onClick?: () => void;
+}) {
+  const translate = useTranslate();
+  if (!item.isGraffiti() || !item.isSealed() || onClick === undefined) {
+    return null;
+  }
+  return (
+    <ModalButton
+      variant="secondary"
+      onClick={onClick}
+      children={translate("InventoryItemUnsealGraffiti")}
+    />
+  );
+}
+
+function InspectItem3d({ onClose, onUnsealGraffiti, uid }: InspectItemProps) {
   const translate = useTranslate();
   const item = useInventoryItem(uid);
   const { api, viewerProps } = useViewer({ item });
@@ -208,11 +229,24 @@ function InspectItem3d({ onClose, uid }: InspectItemProps) {
             </>
           }
           right={
-            <ModalButton
-              variant="secondary"
-              onClick={onClose}
-              children={translate("InspectClose")}
-            />
+            <>
+              <InspectItemUnsealButton
+                item={item}
+                onClick={
+                  onUnsealGraffiti !== undefined
+                    ? () => {
+                        onClose();
+                        onUnsealGraffiti(uid);
+                      }
+                    : undefined
+                }
+              />
+              <ModalButton
+                variant="secondary"
+                onClick={onClose}
+                children={translate("InspectClose")}
+              />
+            </>
           }
         />
       </div>
@@ -221,7 +255,7 @@ function InspectItem3d({ onClose, uid }: InspectItemProps) {
   );
 }
 
-function InspectItem2d({ onClose, uid }: InspectItemProps) {
+function InspectItem2d({ onClose, onUnsealGraffiti, uid }: InspectItemProps) {
   const translate = useTranslate();
   const item = useInventoryItem(uid);
   const { statsForNerds } = usePreferences();
@@ -231,11 +265,10 @@ function InspectItem2d({ onClose, uid }: InspectItemProps) {
     <ClientOnly
       children={() =>
         createPortal(
-          <Overlay className="m-auto lg:w-5xl">
-            <InspectItemHeader item={item} />
-            <div className="text-center">
-              <div className="relative mx-auto inline-block">
-                <ItemImage className="m-auto my-8 max-w-lg" item={item} />
+          <InGameOverlay header={<InspectItemHeader item={item} />}>
+            <div className="flex size-full items-center justify-center">
+              <div className="relative inline-block">
+                <ItemImage className="max-w-lg" item={item} />
                 {item.stickers !== undefined && (
                   <div className="absolute bottom-0 left-0 flex items-center justify-center">
                     {item.someStickers().map(([index, { id, wear }]) => (
@@ -259,24 +292,40 @@ function InspectItem2d({ onClose, uid }: InspectItemProps) {
                 )}
               </div>
             </div>
-            <InspectItemDescription item={item} />
-            <UseItemFooter
-              left={
-                <>
-                  {infoButton}
-                  <InspectItemShareButton item={item} />
-                </>
-              }
-              right={
-                <ModalButton
-                  variant="secondary"
-                  onClick={onClose}
-                  children={translate("InspectClose")}
-                />
-              }
-            />
+            <div className="absolute bottom-8 left-0 w-full">
+              <InspectItemDescription item={item} />
+              <UseItemFooter
+                className="mt-2 max-w-5xl px-8 lg:w-5xl"
+                left={
+                  <>
+                    {infoButton}
+                    <InspectItemShareButton item={item} />
+                  </>
+                }
+                right={
+                  <>
+                    <InspectItemUnsealButton
+                      item={item}
+                      onClick={
+                        onUnsealGraffiti !== undefined
+                          ? () => {
+                              onClose();
+                              onUnsealGraffiti(uid);
+                            }
+                          : undefined
+                      }
+                    />
+                    <ModalButton
+                      variant="secondary"
+                      onClick={onClose}
+                      children={translate("InspectClose")}
+                    />
+                  </>
+                }
+              />
+            </div>
             {infoTooltip}
-          </Overlay>,
+          </InGameOverlay>,
           document.body
         )
       }
@@ -284,7 +333,11 @@ function InspectItem2d({ onClose, uid }: InspectItemProps) {
   );
 }
 
-export function InspectItem({ onClose, uid }: InspectItemProps) {
+export function InspectItem({
+  onClose,
+  onUnsealGraffiti,
+  uid
+}: InspectItemProps) {
   const item = useInventoryItem(uid);
   const { canUse3d } = useViewerAvailability(item);
 
@@ -299,8 +352,16 @@ export function InspectItem({ onClose, uid }: InspectItemProps) {
     return <InspectCharmDetachments onClose={onClose} uid={uid} />;
   }
   return canUse3d ? (
-    <InspectItem3d onClose={onClose} uid={uid} />
+    <InspectItem3d
+      onClose={onClose}
+      onUnsealGraffiti={onUnsealGraffiti}
+      uid={uid}
+    />
   ) : (
-    <InspectItem2d onClose={onClose} uid={uid} />
+    <InspectItem2d
+      onClose={onClose}
+      onUnsealGraffiti={onUnsealGraffiti}
+      uid={uid}
+    />
   );
 }

--- a/app/components/inspect-item.tsx
+++ b/app/components/inspect-item.tsx
@@ -163,7 +163,11 @@ function InspectItemShareButton({ item }: { item: CS2InventoryItem }) {
 }
 
 function InspectItemDescription({ item }: { item: CS2InventoryItem }) {
+  const translate = useTranslate();
+  const isSealedGraffiti =
+    item.isGraffiti() && item.hasCharges() && item.isSealed();
   if (
+    !isSealedGraffiti &&
     (item.parent ?? item).description === undefined &&
     item.description === undefined
   ) {
@@ -171,7 +175,13 @@ function InspectItemDescription({ item }: { item: CS2InventoryItem }) {
   }
   return (
     <div className="m-auto max-w-5xl px-24 pb-4 lg:w-5xl">
-      <ItemDescription item={item} />
+      {isSealedGraffiti ? (
+        <p className="mt-4 whitespace-pre-wrap text-neutral-300">
+          {translate("ItemSealedGraffitiDesc")}
+        </p>
+      ) : (
+        <ItemDescription item={item} />
+      )}
     </div>
   );
 }

--- a/app/components/inventory-item-tooltip.tsx
+++ b/app/components/inventory-item-tooltip.tsx
@@ -12,7 +12,7 @@ import {
 import clsx from "clsx";
 import { ComponentProps } from "react";
 import { has } from "~/utils/misc";
-import { usePreferences } from "./app-context";
+import { usePreferences, useTranslate } from "./app-context";
 import { InventoryItemTooltipContents } from "./inventory-item-tooltip-contents";
 import { ItemDescription } from "./item-description";
 import { InventoryItemTooltipExterior } from "./inventory-item-tooltip-exterior";
@@ -31,6 +31,7 @@ export function InventoryItemTooltip({
   item: CS2InventoryItem;
   forwardRef: typeof props.ref;
 }) {
+  const translate = useTranslate();
   const { statsForNerds } = usePreferences();
   const isContainer = item.isContainer();
   const containerItem =
@@ -42,6 +43,9 @@ export function InventoryItemTooltip({
   const hasSeed = !item.isDefault && item.hasSeed();
   const hasAttributes = hasWear || hasSeed;
   const hasStatTrak = item.statTrak !== undefined;
+  const isUnsealedGraffiti =
+    item.isGraffiti() && item.hasCharges() && !item.isSealed();
+  const isCharmDetachment = item.isCharmDetachment();
   const wear = item.getWear();
 
   // We don't treat graffiti as equippable for a particular team, but in-game it
@@ -77,6 +81,16 @@ export function InventoryItemTooltip({
         />
       )}
       <ItemDescription item={item} />
+      {isUnsealedGraffiti && (
+        <p className="mt-4 text-cyan-200/80">
+          {translate("ItemGraffitiChargesRemaining", String(item.getCharges()))}
+        </p>
+      )}
+      {isCharmDetachment && (
+        <p className="mt-4 text-cyan-200/80">
+          {translate("CharmDetachmentsAvailable", String(item.getCharges()))}
+        </p>
+      )}
       {hasContents && (
         <InventoryItemTooltipContents
           containerItem={containerItem}

--- a/app/components/inventory-item.tsx
+++ b/app/components/inventory-item.tsx
@@ -56,6 +56,7 @@ export function InventoryItem({
   onSwapItemsStatTrak,
   onUnequip,
   onUnlockContainer,
+  onUnsealGraffiti,
   onUseItem,
   ownApplicableKeychains,
   ownApplicablePatches,
@@ -86,6 +87,7 @@ export function InventoryItem({
   onSwapItemsStatTrak?: (uid: number) => void;
   onUnequip?: (uid: number, team?: CS2Team) => void;
   onUnlockContainer?: (uid: number) => void;
+  onUnsealGraffiti?: (uid: number) => void;
   onUseItem?: (uid: number) => void;
   ownApplicableKeychains?: boolean;
   ownApplicablePatches?: boolean;
@@ -138,7 +140,8 @@ export function InventoryItem({
   const isEquippable =
     (item.modelKey === undefined ||
       !inventoryItemEquipHideModel.includes(item.modelKey)) &&
-    !inventoryItemEquipHideType.includes(item.type);
+    !inventoryItemEquipHideType.includes(item.type) &&
+    !item.isSealed();
   const canEquip =
     isEquippable &&
     item.teams === undefined &&
@@ -201,6 +204,7 @@ export function InventoryItem({
   const isStickerSlab = item.isStickerSlab();
   const canSealSticker = item.isSticker() && item.hasDisplayCase();
   const canExtractSticker = item.isStickerDisplayCase();
+  const canUnsealGraffiti = item.isGraffiti() && item.isSealed();
 
   function close(callBeforeClosing: () => void) {
     return function close() {
@@ -384,6 +388,11 @@ export function InventoryItem({
                                   "InventoryItemUnlockContainer"
                                 ),
                                 onClick: close(() => onUnlockContainer?.(uid))
+                              },
+                              {
+                                condition: canUnsealGraffiti,
+                                label: translate("InventoryItemUnsealGraffiti"),
+                                onClick: close(() => onUnsealGraffiti?.(uid))
                               }
                             ],
                             [

--- a/app/components/inventory.tsx
+++ b/app/components/inventory.tsx
@@ -52,6 +52,8 @@ import { useSealItemSticker } from "./hooks/use-seal-item-sticker";
 import { SwapItemsStatTrak } from "./swap-items-stattrak";
 import { UnlockCase } from "./unlock-case";
 import { UnpackItem } from "./unpack-item";
+import { UnsealGraffiti } from "./unseal-graffiti";
+import { useUnsealGraffiti } from "./hooks/use-unseal-graffiti";
 
 export function Inventory() {
   const translate = useTranslate();
@@ -174,6 +176,13 @@ export function Inventory() {
     useUnpackItem();
 
   const {
+    closeUnsealGraffiti,
+    handleUnsealGraffiti,
+    isUnsealingGraffiti,
+    unsealGraffiti
+  } = useUnsealGraffiti();
+
+  const {
     closeDetachCharm,
     detachCharm,
     handleDetachCharm: openDetachCharm,
@@ -259,6 +268,7 @@ export function Inventory() {
     closeSwapItemsStatTrak();
     closeUnlockCase();
     closeUnpackItem();
+    closeUnsealGraffiti();
   }
 
   function handleSelectItem(uid: number) {
@@ -349,6 +359,7 @@ export function Inventory() {
                     onSwapItemsStatTrak: handleSwapItemsStatTrak,
                     onUnequip: handleUnequip,
                     onUnlockContainer: handleUnlockCase,
+                    onUnsealGraffiti: handleUnsealGraffiti,
                     onUseItem: handleUnpackItem,
                     ownApplicableKeychains,
                     ownApplicablePatches,
@@ -438,7 +449,11 @@ export function Inventory() {
       )}
       <Presence present={isInspectingItem(inspectItem)}>
         {isInspectingItem(inspectItem) ? (
-          <InspectItem {...inspectItem} onClose={closeInspectItem} />
+          <InspectItem
+            {...inspectItem}
+            onClose={closeInspectItem}
+            onUnsealGraffiti={handleUnsealGraffiti}
+          />
         ) : null}
       </Presence>
       <Presence present={isDetachingCharm(detachCharm)}>
@@ -453,6 +468,11 @@ export function Inventory() {
             onClose={closeUnpackItem}
             onUnpacked={handleInspectItem}
           />
+        ) : null}
+      </Presence>
+      <Presence present={isUnsealingGraffiti(unsealGraffiti)}>
+        {isUnsealingGraffiti(unsealGraffiti) ? (
+          <UnsealGraffiti {...unsealGraffiti} onClose={closeUnsealGraffiti} />
         ) : null}
       </Presence>
     </>

--- a/app/components/unseal-graffiti.tsx
+++ b/app/components/unseal-graffiti.tsx
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Ian Lucas. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createPortal } from "react-dom";
+import { ClientOnly } from "remix-utils/client-only";
+import { useInventoryItem } from "~/components/hooks/use-inventory-item";
+import { useNameItemString } from "~/components/hooks/use-name-item";
+import { useSync } from "~/components/hooks/use-sync";
+import { SyncAction } from "~/data/sync";
+import { playSound } from "~/utils/sound";
+import { useInventory, useTranslate } from "./app-context";
+import { InGameOverlay } from "./in-game-overlay";
+import { ItemImage } from "./item-image";
+import { ModalButton } from "./modal-button";
+import { UseItemFooter } from "./use-item-footer";
+import { UseItemHeader } from "./use-item-header";
+
+export function UnsealGraffiti({
+  onClose,
+  uid
+}: {
+  onClose: () => void;
+  uid: number;
+}) {
+  const translate = useTranslate();
+  const nameItemString = useNameItemString();
+  const sync = useSync();
+  const [inventory, setInventory] = useInventory();
+  const item = useInventoryItem(uid);
+
+  function handleUnseal() {
+    playSound("inventory_new_item_accept");
+    setInventory(inventory.unsealItem(uid).equip(uid));
+    sync({ type: SyncAction.UnsealItem, uid });
+    sync({ type: SyncAction.Equip, uid });
+    onClose();
+  }
+
+  return (
+    <ClientOnly
+      children={() =>
+        createPortal(
+          <InGameOverlay
+            header={
+              <UseItemHeader
+                actionDesc={translate("UnsealGraffitiDesc")}
+                actionItem={nameItemString(item)}
+                title={translate("UnsealGraffitiTitle")}
+                warning={translate("UnsealGraffitiWarn")}
+              />
+            }
+          >
+            <div className="flex size-full items-center justify-center">
+              <ItemImage className="max-w-lg" item={item} />
+            </div>
+            <div className="absolute bottom-8 left-0 w-full">
+              <UseItemFooter
+                className="mt-2 max-w-5xl px-8 lg:w-5xl"
+                right={
+                  <>
+                    <ModalButton
+                      variant="primary"
+                      onClick={handleUnseal}
+                      children={translate("UnsealGraffitiUse")}
+                    />
+                    <ModalButton
+                      variant="secondary"
+                      onClick={onClose}
+                      children={translate("UnsealGraffitiClose")}
+                    />
+                  </>
+                }
+              />
+            </div>
+          </InGameOverlay>,
+          document.body
+        )
+      }
+    />
+  );
+}

--- a/app/data/sync.ts
+++ b/app/data/sync.ts
@@ -30,5 +30,6 @@ export const SyncAction = {
   SealItemSticker: "seal-item-sticker",
   SwapItemsStatTrak: "swap-items-stattrak",
   Unequip: "unequip",
-  UnpackItem: "unpack-item"
+  UnpackItem: "unpack-item",
+  UnsealItem: "unseal-item"
 } as const;

--- a/app/models/api-credential.server.ts
+++ b/app/models/api-credential.server.ts
@@ -8,6 +8,7 @@ import { prisma } from "~/db.server";
 export const API_AUTH_SCOPE = "api_auth";
 export const API_SCOPE = "api";
 export const INVENTORY_SCOPE = "inventory";
+export const SPRAY_CONSUME_SCOPE = "spray_consume";
 export const STATTRAK_INCREMENT_SCOPE = "stattrak_increment";
 
 export async function isApiKeyValid(apiKey: string, scope?: string[]) {

--- a/app/routes/api.action.sync._index.tsx
+++ b/app/routes/api.action.sync._index.tsx
@@ -217,6 +217,10 @@ const actionShape = z.discriminatedUnion("type", [
     uid: nonNegativeInt
   }),
   z.object({
+    type: z.literal(SyncAction.UnsealItem),
+    uid: nonNegativeInt
+  }),
+  z.object({
     type: z.literal(SyncAction.RemoveItemKeychain),
     targetUid: nonNegativeInt,
     slot: nonNegativeInt
@@ -645,6 +649,9 @@ export const action = api(async ({ request }: Route.ActionArgs) => {
             break;
           case SyncAction.UnpackItem:
             inventory.unpackItem(action.uid);
+            break;
+          case SyncAction.UnsealItem:
+            inventory.unsealItem(action.uid);
             break;
           case SyncAction.RemoveItemKeychain:
             inventory.removeItemKeychain(action.targetUid, action.slot);

--- a/app/routes/api.consume-item-spray._index.tsx
+++ b/app/routes/api.consume-item-spray._index.tsx
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Ian Lucas. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { assert } from "@ianlucas/cs2-lib";
+import { z } from "zod";
+import { api } from "~/api.server";
+import { middleware } from "~/middleware.server";
+import {
+  API_SCOPE,
+  SPRAY_CONSUME_SCOPE,
+  isApiKeyValid
+} from "~/models/api-credential.server";
+import {
+  existsUser,
+  findUniqueUser,
+  manipulateUserInventory
+} from "~/models/user.server";
+import {
+  badRequest,
+  methodNotAllowed,
+  noContent,
+  unauthorized
+} from "~/responses.server";
+import { nonNegativeInt } from "~/utils/shapes";
+import type { Route } from "./+types/api.consume-item-spray._index";
+
+export const action = api(async ({ request }: Route.ActionArgs) => {
+  await middleware(request);
+  if (request.method !== "POST") {
+    throw methodNotAllowed;
+  }
+  const { apiKey, userId, targetUid } = z
+    .object({
+      apiKey: z.string(),
+      userId: z.string(),
+      targetUid: nonNegativeInt
+    })
+    .parse(await request.json());
+
+  if (!(await isApiKeyValid(apiKey, [API_SCOPE, SPRAY_CONSUME_SCOPE]))) {
+    throw unauthorized;
+  }
+
+  if (!(await existsUser(userId))) {
+    throw badRequest;
+  }
+
+  try {
+    const { inventory: rawInventory } = await findUniqueUser(userId);
+    await manipulateUserInventory({
+      rawInventory,
+      userId,
+      manipulate(inventory) {
+        assert(inventory.get(targetUid).isGraffiti());
+        inventory.consumeItemCharges(targetUid);
+      }
+    });
+    return noContent;
+  } catch {
+    return badRequest;
+  }
+});
+
+export { loader } from "./api.$";

--- a/app/routes/api.consume-item-spray._index.tsx
+++ b/app/routes/api.consume-item-spray._index.tsx
@@ -53,7 +53,9 @@ export const action = api(async ({ request }: Route.ActionArgs) => {
       rawInventory,
       userId,
       manipulate(inventory) {
-        assert(inventory.get(targetUid).isGraffiti());
+        const item = inventory.get(targetUid);
+        assert(item.isGraffiti());
+        assert(item.equipped === true);
         inventory.consumeItemCharges(targetUid);
       }
     });

--- a/app/routes/api.increment-item-stattrak._index.tsx
+++ b/app/routes/api.increment-item-stattrak._index.tsx
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { assert } from "@ianlucas/cs2-lib";
 import { z } from "zod";
 import { api } from "~/api.server";
 import { middleware } from "~/middleware.server";
@@ -52,6 +53,12 @@ export const action = api(async ({ request }: Route.ActionArgs) => {
       rawInventory,
       userId,
       manipulate(inventory) {
+        const item = inventory.get(targetUid);
+        assert(
+          item.equipped === true ||
+            item.equippedCT === true ||
+            item.equippedT === true
+        );
         inventory.incrementItemStatTrak(targetUid);
       }
     });

--- a/app/translations/brazilian.ts
+++ b/app/translations/brazilian.ts
@@ -257,6 +257,7 @@ export const brazilian = {
   ItemRarityNameTool: /* csgo_brazilian.txt */"Ferramenta",
   ItemRarityRare: /* csgo_brazilian.txt */"Alta Qualidade",
   ItemRarityUncommon: /* csgo_brazilian.txt */"Nível Moderado",
+  ItemSealedGraffiti: /* csgo_brazilian.txt */"Grafite Lacrado",
   ItemSwapStatTrakAccept: /* csgo_brazilian.txt */"ACEITAR",
   ItemSwapStatTrakClose: /* csgo_brazilian.txt */"Fechar",
   ItemSwapStatTrakDesc: /* csgo_brazilian.txt */"Este item troca as contagens StatTrak™ de dois itens do mesmo tipo.",

--- a/app/translations/brazilian.ts
+++ b/app/translations/brazilian.ts
@@ -258,6 +258,7 @@ export const brazilian = {
   ItemRarityRare: /* csgo_brazilian.txt */"Alta Qualidade",
   ItemRarityUncommon: /* csgo_brazilian.txt */"Nível Moderado",
   ItemSealedGraffiti: /* csgo_brazilian.txt */"Grafite Lacrado",
+  ItemSealedGraffitiDesc: /* csgo_brazilian.txt */"Este é um padrão de grafite ainda lacrado. Ao abri-lo, você receberá cargas para grafitar este padrão 50 vezes no mundo do jogo.",
   ItemSwapStatTrakAccept: /* csgo_brazilian.txt */"ACEITAR",
   ItemSwapStatTrakClose: /* csgo_brazilian.txt */"Fechar",
   ItemSwapStatTrakDesc: /* csgo_brazilian.txt */"Este item troca as contagens StatTrak™ de dois itens do mesmo tipo.",

--- a/app/translations/brazilian.ts
+++ b/app/translations/brazilian.ts
@@ -219,6 +219,7 @@ export const brazilian = {
   InventoryItemUnequipCT: "Desequipar CT",
   InventoryItemUnequipT: "Desequipar T",
   InventoryItemUnlockContainer: /* csgo_brazilian.txt */"Destrancar recipiente",
+  InventoryItemUnsealGraffiti: /* csgo_brazilian.txt */"Abrir e equipar",
   InventoryItemUseItem: /* csgo_brazilian.txt */"Usar item",
   InventoryItemUseStorageUnit: /* csgo_brazilian.txt */"Começar a usar unidade",
   InventoryItemWear: "Desgaste:",
@@ -347,5 +348,10 @@ export const brazilian = {
   UnpackClose: /* csgo_brazilian.txt */"Fechar",
   UnpackDesc: /* csgo_brazilian.txt */"Tem certeza de que deseja abrir este item?",
   UnpackNumberOfItems: /* csgo_brazilian.txt */"Número de itens: {1}",
-  UnpackTitle: /* csgo_brazilian.txt */"Abrir {1}"
+  UnpackTitle: /* csgo_brazilian.txt */"Abrir {1}",
+  UnsealGraffitiClose: /* csgo_brazilian.txt */"Fechar",
+  UnsealGraffitiDesc: /* csgo_brazilian.txt */"Abrir",
+  UnsealGraffitiTitle: /* csgo_brazilian.txt */"Abrir grafite",
+  UnsealGraffitiUse: /* csgo_brazilian.txt */"Abrir grafite",
+  UnsealGraffitiWarn: /* csgo_brazilian.txt */"Este grafite só pode ser aberto uma vez"
 };

--- a/app/translations/brazilian.ts
+++ b/app/translations/brazilian.ts
@@ -228,6 +228,7 @@ export const brazilian = {
   InventorySelectInspectContents: /* csgo_brazilian.txt */"Inspecionando o conteúdo de",
   InventorySelectItemToDeposit: /* csgo_brazilian.txt */"Selecione quais itens guardar",
   InventorySelectItemToRetrieve: /* csgo_brazilian.txt */"Selecione quais itens retirar",
+  ItemGraffitiChargesRemaining: /* csgo_brazilian.txt */"Cargas restantes: {1}",
   ItemRarityAncient: /* csgo_brazilian.txt */"Extraordinário",
   ItemRarityCommon: /* csgo_brazilian.txt */"Nível Básico",
   ItemRarityDefault: /* csgo_brazilian.txt */"Padrão",

--- a/app/translations/bulgarian.ts
+++ b/app/translations/bulgarian.ts
@@ -258,6 +258,7 @@ export const bulgarian = {
   ItemRarityRare: /* csgo_bulgarian.txt */"Висок клас",
   ItemRarityUncommon: /* csgo_bulgarian.txt */"Средна поредица",
   ItemSealedGraffiti: /* csgo_bulgarian.txt */"Запечатани графити",
+  ItemSealedGraffitiDesc: /* csgo_bulgarian.txt */"Това е запечатан контейнер с шаблон за графити. След като бъде разпечатан, ще Ви предостави с достатъчно заряди, така че да приложите шаблона с графити 50 пъти в игралния свят.",
   ItemSwapStatTrakAccept: /* csgo_bulgarian.txt */"ПРИЕМАНЕ",
   ItemSwapStatTrakClose: /* csgo_bulgarian.txt */"Затваряне",
   ItemSwapStatTrakDesc: /* csgo_bulgarian.txt */"Този артикул разменя StatTrak™ стойностите между две оръжия от еднакъв тип.",

--- a/app/translations/bulgarian.ts
+++ b/app/translations/bulgarian.ts
@@ -257,6 +257,7 @@ export const bulgarian = {
   ItemRarityNameTool: /* csgo_bulgarian.txt */"Инструмент",
   ItemRarityRare: /* csgo_bulgarian.txt */"Висок клас",
   ItemRarityUncommon: /* csgo_bulgarian.txt */"Средна поредица",
+  ItemSealedGraffiti: /* csgo_bulgarian.txt */"Запечатани графити",
   ItemSwapStatTrakAccept: /* csgo_bulgarian.txt */"ПРИЕМАНЕ",
   ItemSwapStatTrakClose: /* csgo_bulgarian.txt */"Затваряне",
   ItemSwapStatTrakDesc: /* csgo_bulgarian.txt */"Този артикул разменя StatTrak™ стойностите между две оръжия от еднакъв тип.",

--- a/app/translations/bulgarian.ts
+++ b/app/translations/bulgarian.ts
@@ -220,6 +220,7 @@ export const bulgarian = {
   InventoryItemUnequipCT: "Премахни КТ",
   InventoryItemUnequipT: "Премахни Т",
   InventoryItemUnlockContainer: /* csgo_bulgarian.txt */"Отключване на контейнера",
+  InventoryItemUnsealGraffiti: /* csgo_bulgarian.txt */"Отваряне и екипиране",
   InventoryItemUseItem: /* csgo_bulgarian.txt */"Използване на артикула",
   InventoryItemUseStorageUnit: /* csgo_bulgarian.txt */"Стартиране на ползването на този елемент",
   InventoryItemWear: "Износване:",
@@ -347,5 +348,10 @@ export const bulgarian = {
   UnpackClose: /* csgo_bulgarian.txt */"Затваряне",
   UnpackDesc: /* csgo_bulgarian.txt */"Сигурни ли сте, че искате да разопаковате този артикул?",
   UnpackNumberOfItems: /* csgo_bulgarian.txt */"Брой артикули: {1}",
-  UnpackTitle: /* csgo_bulgarian.txt */"Разопаковане на {1}"
+  UnpackTitle: /* csgo_bulgarian.txt */"Разопаковане на {1}",
+  UnsealGraffitiClose: /* csgo_bulgarian.txt */"Затваряне",
+  UnsealGraffitiDesc: /* csgo_bulgarian.txt */"Отваряне на",
+  UnsealGraffitiTitle: /* csgo_bulgarian.txt */"Отваряне на графити",
+  UnsealGraffitiUse: /* csgo_bulgarian.txt */"Разпечатване на графити",
+  UnsealGraffitiWarn: /* csgo_bulgarian.txt */"Тези графити могат да бъдат разпечатани само веднъж"
 };

--- a/app/translations/bulgarian.ts
+++ b/app/translations/bulgarian.ts
@@ -229,6 +229,7 @@ export const bulgarian = {
   InventorySelectInspectContents: /* csgo_bulgarian.txt */"Оглед на съдържанието",
   InventorySelectItemToDeposit: /* csgo_bulgarian.txt */"Избиране на артикули, които да преместите",
   InventorySelectItemToRetrieve: /* csgo_bulgarian.txt */"Избиране на артикули за набавяне от",
+  ItemGraffitiChargesRemaining: /* csgo_bulgarian.txt */"Оставащи заряди: {1}",
   ItemRarityAncient: /* csgo_bulgarian.txt */"Необикновен тип",
   ItemRarityCommon: /* csgo_bulgarian.txt */"Базов клас",
   ItemRarityDefault: /* csgo_bulgarian.txt */"По подразбиране",

--- a/app/translations/czech.ts
+++ b/app/translations/czech.ts
@@ -228,6 +228,7 @@ export const czech = {
   InventorySelectInspectContents: /* csgo_czech.txt */"Prohlížíš si obsah",
   InventorySelectItemToDeposit: /* csgo_czech.txt */"Vyber předměty, které chceš přesunout do",
   InventorySelectItemToRetrieve: /* csgo_czech.txt */"Vyber předměty, které chceš vyzvednout z",
+  ItemGraffitiChargesRemaining: /* csgo_czech.txt */"Zbývající použití: {1}",
   ItemRarityAncient: /* csgo_czech.txt */"Mimořádná",
   ItemRarityCommon: /* csgo_czech.txt */"Základní třída",
   ItemRarityDefault: /* csgo_czech.txt */"Základní",

--- a/app/translations/czech.ts
+++ b/app/translations/czech.ts
@@ -219,6 +219,7 @@ export const czech = {
   InventoryItemUnequipCT: "Sundat CT",
   InventoryItemUnequipT: "Sundat T",
   InventoryItemUnlockContainer: /* csgo_czech.txt */"Odemknout bednu",
+  InventoryItemUnsealGraffiti: /* csgo_czech.txt */"Rozbalit a vybavit",
   InventoryItemUseItem: /* csgo_czech.txt */"Použít předmět",
   InventoryItemUseStorageUnit: /* csgo_czech.txt */"Začít používat kontejner",
   InventoryItemWear: "Povrch:",
@@ -346,5 +347,10 @@ export const czech = {
   UnpackClose: /* csgo_czech.txt */"Zavřít",
   UnpackDesc: /* csgo_czech.txt */"Opravdu chceš rozbalit tento předmět?",
   UnpackNumberOfItems: /* csgo_czech.txt */"Počet předmětů: {1}",
-  UnpackTitle: /* csgo_czech.txt */"Rozbalit {1}"
+  UnpackTitle: /* csgo_czech.txt */"Rozbalit {1}",
+  UnsealGraffitiClose: /* csgo_czech.txt */"Zavřít",
+  UnsealGraffitiDesc: /* csgo_czech.txt */"Otevřít",
+  UnsealGraffitiTitle: /* csgo_czech.txt */"Rozbalit graffiti",
+  UnsealGraffitiUse: /* csgo_czech.txt */"Rozbalit graffiti",
+  UnsealGraffitiWarn: /* csgo_czech.txt */"Toto graffiti lze rozbalit pouze jednou"
 };

--- a/app/translations/czech.ts
+++ b/app/translations/czech.ts
@@ -257,6 +257,7 @@ export const czech = {
   ItemRarityRare: /* csgo_czech.txt */"Vyšší třída",
   ItemRarityUncommon: /* csgo_czech.txt */"Střední třída",
   ItemSealedGraffiti: /* csgo_czech.txt */"Zabalené graffiti",
+  ItemSealedGraffitiDesc: /* csgo_czech.txt */"Tento předmět je zabalená plechovka s graffiti. Jakmile graffiti rozbalíš, budeš ho moci ve hře 50× nasprejovat.",
   ItemSwapStatTrakAccept: /* csgo_czech.txt */"PŘIJMOUT",
   ItemSwapStatTrakClose: /* csgo_czech.txt */"Zavřít",
   ItemSwapStatTrakDesc: /* csgo_czech.txt */"Tento nástroj prohodí statistiky mezi dvěma předměty stejného typu.",

--- a/app/translations/czech.ts
+++ b/app/translations/czech.ts
@@ -256,6 +256,7 @@ export const czech = {
   ItemRarityNameTool: /* csgo_czech.txt */"Nástroj",
   ItemRarityRare: /* csgo_czech.txt */"Vyšší třída",
   ItemRarityUncommon: /* csgo_czech.txt */"Střední třída",
+  ItemSealedGraffiti: /* csgo_czech.txt */"Zabalené graffiti",
   ItemSwapStatTrakAccept: /* csgo_czech.txt */"PŘIJMOUT",
   ItemSwapStatTrakClose: /* csgo_czech.txt */"Zavřít",
   ItemSwapStatTrakDesc: /* csgo_czech.txt */"Tento nástroj prohodí statistiky mezi dvěma předměty stejného typu.",

--- a/app/translations/danish.ts
+++ b/app/translations/danish.ts
@@ -219,6 +219,7 @@ export const danish = {
   InventoryItemUnequipCT: "Tag af CT",
   InventoryItemUnequipT: "Tag af T",
   InventoryItemUnlockContainer: /* csgo_danish.txt */"Oplås beholder",
+  InventoryItemUnsealGraffiti: /* csgo_danish.txt */"Åbn og tag i brug",
   InventoryItemUseItem: /* csgo_danish.txt */"Anvend genstand",
   InventoryItemUseStorageUnit: /* csgo_danish.txt */"Anvend denne enhed",
   InventoryItemWear: "Slid:",
@@ -346,5 +347,10 @@ export const danish = {
   UnpackClose: /* csgo_danish.txt */"Luk",
   UnpackDesc: /* csgo_danish.txt */"Er du sikker på, at du vil pakke denne genstand ud?",
   UnpackNumberOfItems: /* csgo_danish.txt */"Antal genstande: {1}",
-  UnpackTitle: /* csgo_danish.txt */"Udpak {1}"
+  UnpackTitle: /* csgo_danish.txt */"Udpak {1}",
+  UnsealGraffitiClose: /* csgo_danish.txt */"Luk",
+  UnsealGraffitiDesc: /* csgo_danish.txt */"Åbn",
+  UnsealGraffitiTitle: /* csgo_danish.txt */"Åbn graffiti",
+  UnsealGraffitiUse: /* csgo_danish.txt */"Bryd forseglingen på graffitien",
+  UnsealGraffitiWarn: /* csgo_danish.txt */"Forseglingen på denne graffiti kan kun brydes én gang"
 };

--- a/app/translations/danish.ts
+++ b/app/translations/danish.ts
@@ -228,6 +228,7 @@ export const danish = {
   InventorySelectInspectContents: /* csgo_danish.txt */"Inspicerer indholdet af",
   InventorySelectItemToDeposit: /* csgo_danish.txt */"Vælg genstande at flytte til",
   InventorySelectItemToRetrieve: /* csgo_danish.txt */"Vælg genstande at hente fra",
+  ItemGraffitiChargesRemaining: /* csgo_danish.txt */"Ladninger tilbage: {1}",
   ItemRarityAncient: /* csgo_danish.txt */"Ekstraordinær",
   ItemRarityCommon: /* csgo_danish.txt */"Basiskvalitet",
   ItemRarityDefault: /* csgo_danish.txt */"Standard",

--- a/app/translations/danish.ts
+++ b/app/translations/danish.ts
@@ -257,6 +257,7 @@ export const danish = {
   ItemRarityRare: /* csgo_danish.txt */"Højkvalitet",
   ItemRarityUncommon: /* csgo_danish.txt */"Middelkvalitet",
   ItemSealedGraffiti: /* csgo_danish.txt */"Forseglet graffiti",
+  ItemSealedGraffitiDesc: /* csgo_danish.txt */"Dette er en forseglet beholder med et graffitimønster. Når dette graffitimønsters forsegling brydes, giver den dig nok ladninger til at anvende graffitimønsteret 50 gange i spillets verden.",
   ItemSwapStatTrakAccept: /* csgo_danish.txt */"ACCEPTER",
   ItemSwapStatTrakClose: /* csgo_danish.txt */"Luk",
   ItemSwapStatTrakDesc: /* csgo_danish.txt */"Denne genstand bytter StatTrak™-værdier mellem to af den samme genstandstype.",

--- a/app/translations/danish.ts
+++ b/app/translations/danish.ts
@@ -256,6 +256,7 @@ export const danish = {
   ItemRarityNameTool: /* csgo_danish.txt */"Værktøj",
   ItemRarityRare: /* csgo_danish.txt */"Højkvalitet",
   ItemRarityUncommon: /* csgo_danish.txt */"Middelkvalitet",
+  ItemSealedGraffiti: /* csgo_danish.txt */"Forseglet graffiti",
   ItemSwapStatTrakAccept: /* csgo_danish.txt */"ACCEPTER",
   ItemSwapStatTrakClose: /* csgo_danish.txt */"Luk",
   ItemSwapStatTrakDesc: /* csgo_danish.txt */"Denne genstand bytter StatTrak™-værdier mellem to af den samme genstandstype.",

--- a/app/translations/dutch.ts
+++ b/app/translations/dutch.ts
@@ -257,6 +257,7 @@ export const dutch = {
   ItemRarityRare: /* csgo_dutch.txt */"Hoogwaardig",
   ItemRarityUncommon: /* csgo_dutch.txt */"Gemiddeld",
   ItemSealedGraffiti: /* csgo_dutch.txt */"Verzegelde graffiti",
+  ItemSealedGraffitiDesc: /* csgo_dutch.txt */"Dit is een verzegelde doos met een graffitipatroon. Zodra het graffitipatroon wordt ontzegeld, geeft het je genoeg ladingen om het graffitipatroon 50 keer op de wereld in het spel toe te passen.",
   ItemSwapStatTrakAccept: /* csgo_dutch.txt */"ACCEPTEREN",
   ItemSwapStatTrakClose: /* csgo_dutch.txt */"Sluiten",
   ItemSwapStatTrakDesc: /* csgo_dutch.txt */"Hiermee verwissel je de StatTrak™-waarden van twee voorwerpen van hetzelfde type.",

--- a/app/translations/dutch.ts
+++ b/app/translations/dutch.ts
@@ -219,6 +219,7 @@ export const dutch = {
   InventoryItemUnequipCT: "Uitdoen CT",
   InventoryItemUnequipT: "Uitdoen T",
   InventoryItemUnlockContainer: /* csgo_dutch.txt */"Kist openen",
+  InventoryItemUnsealGraffiti: /* csgo_dutch.txt */"Openen en uitrusten",
   InventoryItemUseItem: /* csgo_dutch.txt */"Voorwerp gebruiken",
   InventoryItemUseStorageUnit: /* csgo_dutch.txt */"Deze eenheid gebruiken",
   InventoryItemWear: "Slijtage:",
@@ -346,5 +347,10 @@ export const dutch = {
   UnpackClose: /* csgo_dutch.txt */"Sluiten",
   UnpackDesc: /* csgo_dutch.txt */"Weet je zeker dat je dit voorwerp wilt uitpakken?",
   UnpackNumberOfItems: /* csgo_dutch.txt */"Aantal voorwerpen: {1}",
-  UnpackTitle: /* csgo_dutch.txt */"{1} uitpakken"
+  UnpackTitle: /* csgo_dutch.txt */"{1} uitpakken",
+  UnsealGraffitiClose: /* csgo_dutch.txt */"Sluiten",
+  UnsealGraffitiDesc: /* csgo_dutch.txt */"openen",
+  UnsealGraffitiTitle: /* csgo_dutch.txt */"Graffiti openen",
+  UnsealGraffitiUse: /* csgo_dutch.txt */"Graffiti ontzegelen",
+  UnsealGraffitiWarn: /* csgo_dutch.txt */"Deze graffiti kan maar één keer uitgepakt worden"
 };

--- a/app/translations/dutch.ts
+++ b/app/translations/dutch.ts
@@ -228,6 +228,7 @@ export const dutch = {
   InventorySelectInspectContents: /* csgo_dutch.txt */"Inhoud controleren van",
   InventorySelectItemToDeposit: /* csgo_dutch.txt */"Kies de voorwerpen die je wilt verplaatsen in",
   InventorySelectItemToRetrieve: /* csgo_dutch.txt */"Kies de voorwerpen die je wilt ophalen van",
+  ItemGraffitiChargesRemaining: /* csgo_dutch.txt */"Resterende ladingen: {1}",
   ItemRarityAncient: /* csgo_dutch.txt */"Bijzonder",
   ItemRarityCommon: /* csgo_dutch.txt */"Standaard",
   ItemRarityDefault: /* csgo_dutch.txt */"Standaard",

--- a/app/translations/dutch.ts
+++ b/app/translations/dutch.ts
@@ -256,6 +256,7 @@ export const dutch = {
   ItemRarityNameTool: /* csgo_dutch.txt */"Gereedschap",
   ItemRarityRare: /* csgo_dutch.txt */"Hoogwaardig",
   ItemRarityUncommon: /* csgo_dutch.txt */"Gemiddeld",
+  ItemSealedGraffiti: /* csgo_dutch.txt */"Verzegelde graffiti",
   ItemSwapStatTrakAccept: /* csgo_dutch.txt */"ACCEPTEREN",
   ItemSwapStatTrakClose: /* csgo_dutch.txt */"Sluiten",
   ItemSwapStatTrakDesc: /* csgo_dutch.txt */"Hiermee verwissel je de StatTrak™-waarden van twee voorwerpen van hetzelfde type.",

--- a/app/translations/english.ts
+++ b/app/translations/english.ts
@@ -231,6 +231,7 @@ export const english = {
   InventorySelectInspectContents: /* csgo_english.txt */"Inspecting contents of",
   InventorySelectItemToDeposit: /* csgo_english.txt */"Select items to move into",
   InventorySelectItemToRetrieve: /* csgo_english.txt */"Select items to retrieve from",
+  ItemGraffitiChargesRemaining: /* csgo_english.txt */"Charges Remaining: {1}",
   ItemRarityAncient: /* csgo_english.txt */"Extraordinary",
   ItemRarityCommon: /* csgo_english.txt */"Base Grade",
   ItemRarityDefault: /* csgo_english.txt */"Default",

--- a/app/translations/english.ts
+++ b/app/translations/english.ts
@@ -260,6 +260,7 @@ export const english = {
   ItemRarityNameTool: /* csgo_english.txt */"Tool",
   ItemRarityRare: /* csgo_english.txt */"High Grade",
   ItemRarityUncommon: /* csgo_english.txt */"Medium Grade",
+  ItemSealedGraffiti: /* csgo_english.txt */"Sealed Graffiti",
   ItemSwapStatTrakAccept: /* csgo_english.txt */"ACCEPT",
   ItemSwapStatTrakClose: /* csgo_english.txt */"Close",
   ItemSwapStatTrakDesc: /* csgo_english.txt */"This item swaps StatTrak™ values between two of the same item type.",

--- a/app/translations/english.ts
+++ b/app/translations/english.ts
@@ -222,6 +222,7 @@ export const english = {
   InventoryItemUnequipCT: "Unequip CT",
   InventoryItemUnequipT: "Unequip T",
   InventoryItemUnlockContainer: /* csgo_english.txt */"Unlock Container",
+  InventoryItemUnsealGraffiti: /* csgo_english.txt */"Open and Equip",
   InventoryItemUseItem: /* csgo_english.txt */"Use Item",
   InventoryItemUseStorageUnit: /* csgo_english.txt */"Start Using This Unit",
   InventoryItemWear: "Wear:",
@@ -380,5 +381,10 @@ export const english = {
   UnpackClose: /* csgo_english.txt */"Close",
   UnpackDesc: /* csgo_english.txt */"Are you sure you want to unpack this item?",
   UnpackNumberOfItems: /* csgo_english.txt */"Number of Items: {1}",
-  UnpackTitle: /* csgo_english.txt */"Unpack {1}"
+  UnpackTitle: /* csgo_english.txt */"Unpack {1}",
+  UnsealGraffitiClose: /* csgo_english.txt */"Close",
+  UnsealGraffitiDesc: /* csgo_english.txt */"Open",
+  UnsealGraffitiTitle: /* csgo_english.txt */"Open Graffiti",
+  UnsealGraffitiUse: /* csgo_english.txt */"Unseal Graffiti",
+  UnsealGraffitiWarn: /* csgo_english.txt */"This graffiti can only be unsealed once"
 };

--- a/app/translations/english.ts
+++ b/app/translations/english.ts
@@ -261,6 +261,7 @@ export const english = {
   ItemRarityRare: /* csgo_english.txt */"High Grade",
   ItemRarityUncommon: /* csgo_english.txt */"Medium Grade",
   ItemSealedGraffiti: /* csgo_english.txt */"Sealed Graffiti",
+  ItemSealedGraffitiDesc: /* csgo_english.txt */"This is a sealed container of a graffiti pattern. Once this graffiti pattern is unsealed, it will provide you with enough charges to apply the graffiti pattern 50 times to the in-game world.",
   ItemSwapStatTrakAccept: /* csgo_english.txt */"ACCEPT",
   ItemSwapStatTrakClose: /* csgo_english.txt */"Close",
   ItemSwapStatTrakDesc: /* csgo_english.txt */"This item swaps StatTrak™ values between two of the same item type.",

--- a/app/translations/finnish.ts
+++ b/app/translations/finnish.ts
@@ -219,6 +219,7 @@ export const finnish = {
   InventoryItemUnequipCT: "Poista CT",
   InventoryItemUnequipT: "Poista T",
   InventoryItemUnlockContainer: /* csgo_finnish.txt */"Avaa säiliö",
+  InventoryItemUnsealGraffiti: /* csgo_finnish.txt */"Avaa ja varusta",
   InventoryItemUseItem: /* csgo_finnish.txt */"Käytä esinettä",
   InventoryItemUseStorageUnit: /* csgo_finnish.txt */"Aloita varastolaatikon käyttö",
   InventoryItemWear: "Kuluminen:",
@@ -346,5 +347,10 @@ export const finnish = {
   UnpackClose: /* csgo_finnish.txt */"Sulje",
   UnpackDesc: /* csgo_finnish.txt */"Haluatko varmasti purkaa esineen pakkauksesta?",
   UnpackNumberOfItems: /* csgo_finnish.txt */"Esineiden määrä: {1}",
-  UnpackTitle: /* csgo_finnish.txt */"Avaa {1}"
+  UnpackTitle: /* csgo_finnish.txt */"Avaa {1}",
+  UnsealGraffitiClose: /* csgo_finnish.txt */"Sulje",
+  UnsealGraffitiDesc: /* csgo_finnish.txt */"Avaa",
+  UnsealGraffitiTitle: /* csgo_finnish.txt */"Avaa graffiti",
+  UnsealGraffitiUse: /* csgo_finnish.txt */"Avaa graffiti",
+  UnsealGraffitiWarn: /* csgo_finnish.txt */"Graffitin voi avata vain kerran"
 };

--- a/app/translations/finnish.ts
+++ b/app/translations/finnish.ts
@@ -257,6 +257,7 @@ export const finnish = {
   ItemRarityRare: /* csgo_finnish.txt */"Korkean tason",
   ItemRarityUncommon: /* csgo_finnish.txt */"Keskitason",
   ItemSealedGraffiti: /* csgo_finnish.txt */"Sinetöity graffiti",
+  ItemSealedGraffitiDesc: /* csgo_finnish.txt */"Tämä on sinetöity graffitikuviosäiliö. Säiliön avaaminen antaa 50 latausta kyseisen graffitin käyttöön.",
   ItemSwapStatTrakAccept: /* csgo_finnish.txt */"HYVÄKSY",
   ItemSwapStatTrakClose: /* csgo_finnish.txt */"Sulje",
   ItemSwapStatTrakDesc: /* csgo_finnish.txt */"Tämä esine vaihtaa kahden samanlaisen aseen StatTrak™-arvot keskenään.",

--- a/app/translations/finnish.ts
+++ b/app/translations/finnish.ts
@@ -228,6 +228,7 @@ export const finnish = {
   InventorySelectInspectContents: /* csgo_finnish.txt */"Tarkastellaan sisältöä kohteelle:",
   InventorySelectItemToDeposit: /* csgo_finnish.txt */"Valitse siirrettävät esineet",
   InventorySelectItemToRetrieve: /* csgo_finnish.txt */"Valitse siirrettävät esineet",
+  ItemGraffitiChargesRemaining: /* csgo_finnish.txt */"Käyttökertoja jäljellä: {1}",
   ItemRarityAncient: /* csgo_finnish.txt */"Merkittävä",
   ItemRarityCommon: /* csgo_finnish.txt */"Perustason",
   ItemRarityDefault: /* csgo_finnish.txt */"Oletus",

--- a/app/translations/finnish.ts
+++ b/app/translations/finnish.ts
@@ -256,6 +256,7 @@ export const finnish = {
   ItemRarityNameTool: /* csgo_finnish.txt */"työkalu",
   ItemRarityRare: /* csgo_finnish.txt */"Korkean tason",
   ItemRarityUncommon: /* csgo_finnish.txt */"Keskitason",
+  ItemSealedGraffiti: /* csgo_finnish.txt */"Sinetöity graffiti",
   ItemSwapStatTrakAccept: /* csgo_finnish.txt */"HYVÄKSY",
   ItemSwapStatTrakClose: /* csgo_finnish.txt */"Sulje",
   ItemSwapStatTrakDesc: /* csgo_finnish.txt */"Tämä esine vaihtaa kahden samanlaisen aseen StatTrak™-arvot keskenään.",

--- a/app/translations/french.ts
+++ b/app/translations/french.ts
@@ -257,6 +257,7 @@ export const french = {
   ItemRarityRare: /* csgo_french.txt */"Qualité supérieure",
   ItemRarityUncommon: /* csgo_french.txt */"Qualité moyenne",
   ItemSealedGraffiti: /* csgo_french.txt */"Graffiti scellé",
+  ItemSealedGraffitiDesc: /* csgo_french.txt */"Ceci est un conteneur scellé d'un motif graffiti. Une fois ce motif graffiti descellé, vous pourrez l'appliquer en jeu 50 fois.",
   ItemSwapStatTrakAccept: /* csgo_french.txt */"ACCEPTER",
   ItemSwapStatTrakClose: /* csgo_french.txt */"Fermer",
   ItemSwapStatTrakDesc: /* csgo_french.txt */"Cet item permet de permuter les valeurs StatTrak™ entre deux types d'items identiques.",

--- a/app/translations/french.ts
+++ b/app/translations/french.ts
@@ -256,6 +256,7 @@ export const french = {
   ItemRarityNameTool: /* csgo_french.txt */"Outil",
   ItemRarityRare: /* csgo_french.txt */"Qualité supérieure",
   ItemRarityUncommon: /* csgo_french.txt */"Qualité moyenne",
+  ItemSealedGraffiti: /* csgo_french.txt */"Graffiti scellé",
   ItemSwapStatTrakAccept: /* csgo_french.txt */"ACCEPTER",
   ItemSwapStatTrakClose: /* csgo_french.txt */"Fermer",
   ItemSwapStatTrakDesc: /* csgo_french.txt */"Cet item permet de permuter les valeurs StatTrak™ entre deux types d'items identiques.",

--- a/app/translations/french.ts
+++ b/app/translations/french.ts
@@ -228,6 +228,7 @@ export const french = {
   InventorySelectInspectContents: /* csgo_french.txt */"Examen du contenu de",
   InventorySelectItemToDeposit: /* csgo_french.txt */"Sélectionnez les objets à déplacer",
   InventorySelectItemToRetrieve: /* csgo_french.txt */"Sélectionner les objets à récupérer",
+  ItemGraffitiChargesRemaining: /* csgo_french.txt */"Charges restantes : {1}",
   ItemRarityAncient: /* csgo_french.txt */"Extraordinaire",
   ItemRarityCommon: /* csgo_french.txt */"Qualité de base",
   ItemRarityDefault: /* csgo_french.txt */"Défaut",

--- a/app/translations/french.ts
+++ b/app/translations/french.ts
@@ -219,6 +219,7 @@ export const french = {
   InventoryItemUnequipCT: "Retirer CT",
   InventoryItemUnequipT: "Retirer T",
   InventoryItemUnlockContainer: /* csgo_french.txt */"Ouvrir le conteneur",
+  InventoryItemUnsealGraffiti: /* csgo_french.txt */"Ouvrir et équiper",
   InventoryItemUseItem: /* csgo_french.txt */"Utiliser cet item",
   InventoryItemUseStorageUnit: /* csgo_french.txt */"Commencer à utiliser cette unité",
   InventoryItemWear: "Usure :",
@@ -346,5 +347,10 @@ export const french = {
   UnpackClose: /* csgo_french.txt */"Fermer",
   UnpackDesc: /* csgo_french.txt */"Voulez-vous vraiment déballer cet item ?",
   UnpackNumberOfItems: /* csgo_french.txt */"Nombre d'objets : {1}",
-  UnpackTitle: /* csgo_french.txt */"Déballer {1}"
+  UnpackTitle: /* csgo_french.txt */"Déballer {1}",
+  UnsealGraffitiClose: /* csgo_french.txt */"Fermer",
+  UnsealGraffitiDesc: /* csgo_french.txt */"Ouvrir",
+  UnsealGraffitiTitle: /* csgo_french.txt */"Ouvrir le graffiti",
+  UnsealGraffitiUse: /* csgo_french.txt */"Desceller le graffiti",
+  UnsealGraffitiWarn: /* csgo_french.txt */"Ce graffiti ne peut être descellé qu'une seule fois"
 };

--- a/app/translations/german.ts
+++ b/app/translations/german.ts
@@ -219,6 +219,7 @@ export const german = {
   InventoryItemUnequipCT: "AT ablegen",
   InventoryItemUnequipT: "T ablegen",
   InventoryItemUnlockContainer: /* csgo_german.txt */"Behälter öffnen",
+  InventoryItemUnsealGraffiti: /* csgo_german.txt */"Öffnen & Ausrüsten",
   InventoryItemUseItem: /* csgo_german.txt */"Gegenstand benutzen",
   InventoryItemUseStorageUnit: /* csgo_german.txt */"Diese Einheit verwenden",
   InventoryItemWear: "Abnutzung:",
@@ -346,5 +347,10 @@ export const german = {
   UnpackClose: /* csgo_german.txt */"Schließen",
   UnpackDesc: /* csgo_german.txt */"Möchten Sie diesen Gegenstand wirklich auspacken?",
   UnpackNumberOfItems: /* csgo_german.txt */"Anzahl der Gegenstände: {1}",
-  UnpackTitle: /* csgo_german.txt */"{1} auspacken"
+  UnpackTitle: /* csgo_german.txt */"{1} auspacken",
+  UnsealGraffitiClose: /* csgo_german.txt */"Schließen",
+  UnsealGraffitiDesc: /* csgo_german.txt */"öffnen",
+  UnsealGraffitiTitle: /* csgo_german.txt */"Graffito öffnen",
+  UnsealGraffitiUse: /* csgo_german.txt */"Graffito entsiegeln",
+  UnsealGraffitiWarn: /* csgo_german.txt */"Dieses Graffito kann nur einmal entsiegelt werden"
 };

--- a/app/translations/german.ts
+++ b/app/translations/german.ts
@@ -256,6 +256,7 @@ export const german = {
   ItemRarityNameTool: /* csgo_german.txt */"Werkzeug",
   ItemRarityRare: /* csgo_german.txt */"Hohe Qualität",
   ItemRarityUncommon: /* csgo_german.txt */"Mittlere Qualität",
+  ItemSealedGraffiti: /* csgo_german.txt */"Versiegeltes Graffito",
   ItemSwapStatTrakAccept: /* csgo_german.txt */"ÜBERNEHMEN",
   ItemSwapStatTrakClose: /* csgo_german.txt */"Schließen",
   ItemSwapStatTrakDesc: /* csgo_german.txt */"Dieser Gegenstand tauscht die StatTrak™-Werte zweier Gegenstände gleichen Typs aus.",

--- a/app/translations/german.ts
+++ b/app/translations/german.ts
@@ -257,6 +257,7 @@ export const german = {
   ItemRarityRare: /* csgo_german.txt */"Hohe Qualität",
   ItemRarityUncommon: /* csgo_german.txt */"Mittlere Qualität",
   ItemSealedGraffiti: /* csgo_german.txt */"Versiegeltes Graffito",
+  ItemSealedGraffitiDesc: /* csgo_german.txt */"Dies ist das versiegelte Gefäß eines Graffitimusters. Wenn dieses Graffitimuster entsiegelt wird, erhalten Sie genug Aufladungen, um das Graffitimuster 50-mal in der Spielwelt zu sprühen.",
   ItemSwapStatTrakAccept: /* csgo_german.txt */"ÜBERNEHMEN",
   ItemSwapStatTrakClose: /* csgo_german.txt */"Schließen",
   ItemSwapStatTrakDesc: /* csgo_german.txt */"Dieser Gegenstand tauscht die StatTrak™-Werte zweier Gegenstände gleichen Typs aus.",

--- a/app/translations/german.ts
+++ b/app/translations/german.ts
@@ -228,6 +228,7 @@ export const german = {
   InventorySelectInspectContents: /* csgo_german.txt */"Inhalte von:",
   InventorySelectItemToDeposit: /* csgo_german.txt */"Gegenstände zum Verschieben auswählen:",
   InventorySelectItemToRetrieve: /* csgo_german.txt */"Gegenstände zum Abrufen auswählen:",
+  ItemGraffitiChargesRemaining: /* csgo_german.txt */"Verbleibende Sprays: {1}",
   ItemRarityAncient: /* csgo_german.txt */"Außerordentlich",
   ItemRarityCommon: /* csgo_german.txt */"Standardqualität",
   ItemRarityDefault: /* csgo_german.txt */"Standard",

--- a/app/translations/greek.ts
+++ b/app/translations/greek.ts
@@ -220,6 +220,7 @@ export const greek = {
   InventoryItemUnequipCT: "Παρόπλιση CT",
   InventoryItemUnequipT: "Παρόπλιση T",
   InventoryItemUnlockContainer: /* csgo_greek.txt */"Ξεκλείδωμα κιβωτίου",
+  InventoryItemUnsealGraffiti: /* csgo_greek.txt */"Άνοιγμα & εξόπλιση",
   InventoryItemUseItem: /* csgo_greek.txt */"Χρήση αντικειμένου",
   InventoryItemUseStorageUnit: /* csgo_greek.txt */"Έναρξη χρήσης κιβωτίου",
   InventoryItemWear: "Φθορά:",
@@ -347,5 +348,10 @@ export const greek = {
   UnpackClose: /* csgo_greek.txt */"ΚΛΕΙΣΙΜΟ",
   UnpackDesc: /* csgo_greek.txt */"Θέλετε σίγουρα να ανοίξετε αυτό το αντικείμενο;",
   UnpackNumberOfItems: /* csgo_greek.txt */"Αριθμός αντικειμένων: {1}",
-  UnpackTitle: /* csgo_greek.txt */"Άνοιγμα {1}"
+  UnpackTitle: /* csgo_greek.txt */"Άνοιγμα {1}",
+  UnsealGraffitiClose: /* csgo_greek.txt */"ΚΛΕΙΣΙΜΟ",
+  UnsealGraffitiDesc: /* csgo_greek.txt */"Άνοιγμα",
+  UnsealGraffitiTitle: /* csgo_greek.txt */"Άνοιγμα γκράφιτι",
+  UnsealGraffitiUse: /* csgo_greek.txt */"Ξεσφράγισμα γκράφιτι",
+  UnsealGraffitiWarn: /* csgo_greek.txt */"Αυτό το γκράφιτι μπορεί να ξεσφραγιστεί μόνο μία φορά"
 };

--- a/app/translations/greek.ts
+++ b/app/translations/greek.ts
@@ -257,6 +257,7 @@ export const greek = {
   ItemRarityNameTool: /* csgo_greek.txt */"Εργαλείο",
   ItemRarityRare: /* csgo_greek.txt */"High Grade",
   ItemRarityUncommon: /* csgo_greek.txt */"Medium Grade",
+  ItemSealedGraffiti: /* csgo_greek.txt */"Σφραγισμένο γκράφιτι",
   ItemSwapStatTrakAccept: /* csgo_greek.txt */"ΑΠΟΔΟΧΗ",
   ItemSwapStatTrakClose: /* csgo_greek.txt */"ΚΛΕΙΣΙΜΟ",
   ItemSwapStatTrakDesc: /* csgo_greek.txt */"Αυτό το αντικείμενο εναλλάσσει τις τιμές StatTrak™ μεταξύ δύο αντικειμένων ίδιου τύπου.",

--- a/app/translations/greek.ts
+++ b/app/translations/greek.ts
@@ -229,6 +229,7 @@ export const greek = {
   InventorySelectInspectContents: /* csgo_greek.txt */"Επιθεωρείτε τα περιεχόμενα από",
   InventorySelectItemToDeposit: /* csgo_greek.txt */"Επιλέξτε αντικείμενα για να μετακινήσετε σε",
   InventorySelectItemToRetrieve: /* csgo_greek.txt */"Επιλέξτε αντικείμενα για να λάβετε",
+  ItemGraffitiChargesRemaining: /* csgo_greek.txt */"Υπόλοιπες φορτίσεις: {1}",
   ItemRarityAncient: /* csgo_greek.txt */"Extraordinary",
   ItemRarityCommon: /* csgo_greek.txt */"Base Grade",
   ItemRarityDefault: /* csgo_greek.txt */"Προεπιλογή",

--- a/app/translations/greek.ts
+++ b/app/translations/greek.ts
@@ -258,6 +258,7 @@ export const greek = {
   ItemRarityRare: /* csgo_greek.txt */"High Grade",
   ItemRarityUncommon: /* csgo_greek.txt */"Medium Grade",
   ItemSealedGraffiti: /* csgo_greek.txt */"Σφραγισμένο γκράφιτι",
+  ItemSealedGraffitiDesc: /* csgo_greek.txt */"Πρόκειται για ένα σφραγισμένο κιβώτιο ενός σχεδίου γκράφιτι. Μόλις αυτό το σχέδιο γκράφιτι αποσφραγιστεί, θα σας παρέχει αρκετές χρήσεις για να εφαρμόσετε το σχέδιο 50 φορές στον εντός παιχνιδιού κόσμο.",
   ItemSwapStatTrakAccept: /* csgo_greek.txt */"ΑΠΟΔΟΧΗ",
   ItemSwapStatTrakClose: /* csgo_greek.txt */"ΚΛΕΙΣΙΜΟ",
   ItemSwapStatTrakDesc: /* csgo_greek.txt */"Αυτό το αντικείμενο εναλλάσσει τις τιμές StatTrak™ μεταξύ δύο αντικειμένων ίδιου τύπου.",

--- a/app/translations/hungarian.ts
+++ b/app/translations/hungarian.ts
@@ -219,6 +219,7 @@ export const hungarian = {
   InventoryItemUnequipCT: "CT letevése",
   InventoryItemUnequipT: "T letevése",
   InventoryItemUnlockContainer: /* csgo_hungarian.txt */"Tároló kinyitása",
+  InventoryItemUnsealGraffiti: /* csgo_hungarian.txt */"Kinyit és felszerel",
   InventoryItemUseItem: /* csgo_hungarian.txt */"Használ",
   InventoryItemUseStorageUnit: /* csgo_hungarian.txt */"Egység használatának megkezdése",
   InventoryItemWear: "Kopottság:",
@@ -343,5 +344,10 @@ export const hungarian = {
   UnpackClose: /* csgo_hungarian.txt */"Bezár",
   UnpackDesc: /* csgo_hungarian.txt */"Biztosan ki akarod csomagolni ezt a tárgyat?",
   UnpackNumberOfItems: /* csgo_hungarian.txt */"Tárgyak száma: {1}",
-  UnpackTitle: /* csgo_hungarian.txt */"{1} kicsomagolása"
+  UnpackTitle: /* csgo_hungarian.txt */"{1} kicsomagolása",
+  UnsealGraffitiClose: /* csgo_hungarian.txt */"Bezár",
+  UnsealGraffitiDesc: /* csgo_hungarian.txt */"kinyitása",
+  UnsealGraffitiTitle: /* csgo_hungarian.txt */"Falfirka kinyitása",
+  UnsealGraffitiUse: /* csgo_hungarian.txt */"Graffiti felbontása",
+  UnsealGraffitiWarn: /* csgo_hungarian.txt */"Ezt a falfirkát csak egyszer lehet felbontani"
 };

--- a/app/translations/hungarian.ts
+++ b/app/translations/hungarian.ts
@@ -256,6 +256,7 @@ export const hungarian = {
   ItemRarityNameTool: /* csgo_hungarian.txt */"Eszköz",
   ItemRarityRare: /* csgo_hungarian.txt */"Magas fokozatú",
   ItemRarityUncommon: /* csgo_hungarian.txt */"Közép fokozatú",
+  ItemSealedGraffiti: /* csgo_hungarian.txt */"Lezárt falfirka",
   ItemSwapStatTrakAccept: /* csgo_hungarian.txt */"ELFOGAD",
   ItemSwapStatTrakClose: /* csgo_hungarian.txt */"Bezár",
   ItemSwapStatTrakDesc: /* csgo_hungarian.txt */"Ez a tárgy StatTrak™ értékeket cserél két ugyanolyan típusú tárgy között.",

--- a/app/translations/hungarian.ts
+++ b/app/translations/hungarian.ts
@@ -228,6 +228,7 @@ export const hungarian = {
   InventorySelectInspectContents: /* csgo_hungarian.txt */"Tartalom megvizsgálása",
   InventorySelectItemToDeposit: /* csgo_hungarian.txt */"Válassz behelyezendő tárgyakat",
   InventorySelectItemToRetrieve: /* csgo_hungarian.txt */"Válassz kiveendő tárgyakat",
+  ItemGraffitiChargesRemaining: /* csgo_hungarian.txt */"Maradék töltet: {1}",
   ItemRarityAncient: /* csgo_hungarian.txt */"Rendkívüli",
   ItemRarityCommon: /* csgo_hungarian.txt */"Alap fokozatú",
   ItemRarityDefault: /* csgo_hungarian.txt */"Alapértelmezett",

--- a/app/translations/hungarian.ts
+++ b/app/translations/hungarian.ts
@@ -257,6 +257,7 @@ export const hungarian = {
   ItemRarityRare: /* csgo_hungarian.txt */"Magas fokozatú",
   ItemRarityUncommon: /* csgo_hungarian.txt */"Közép fokozatú",
   ItemSealedGraffiti: /* csgo_hungarian.txt */"Lezárt falfirka",
+  ItemSealedGraffitiDesc: /* csgo_hungarian.txt */"Ez egy falfirka-mintát tartalmazó lezárt tároló. Miután a falfirka-minta felbontásra kerül, elegendő töltetet fog biztosítani, hogy 50 alkalommal használhasd a falfirka-mintát a játékvilágban.",
   ItemSwapStatTrakAccept: /* csgo_hungarian.txt */"ELFOGAD",
   ItemSwapStatTrakClose: /* csgo_hungarian.txt */"Bezár",
   ItemSwapStatTrakDesc: /* csgo_hungarian.txt */"Ez a tárgy StatTrak™ értékeket cserél két ugyanolyan típusú tárgy között.",

--- a/app/translations/indonesian.ts
+++ b/app/translations/indonesian.ts
@@ -254,6 +254,7 @@ export const indonesian = {
   ItemRarityRare: /* csgo_indonesian.txt */"Kualitas Tinggi",
   ItemRarityUncommon: /* csgo_indonesian.txt */"Kualitas Menengah",
   ItemSealedGraffiti: /* csgo_indonesian.txt */"Grafiti Tersegel",
+  ItemSealedGraffitiDesc: /* csgo_indonesian.txt */"Ini adalah kontainer pola grafiti yang masih tersegel. Begitu segel pola grafiti dibuka, kamu akan mendapatkan kesempatan untuk menyemprotkan pola grafiti sebanyak 50 kali di dalam permainan.",
   ItemSwapStatTrakAccept: /* csgo_indonesian.txt */"TERIMA",
   ItemSwapStatTrakClose: /* csgo_indonesian.txt */"Tutup",
   ItemSwapStatTrakDesc: /* csgo_indonesian.txt */"Item ini menukar nilai StatTrak™ antara dua jenis item yang sama.",

--- a/app/translations/indonesian.ts
+++ b/app/translations/indonesian.ts
@@ -253,6 +253,7 @@ export const indonesian = {
   ItemRarityNameTool: /* csgo_indonesian.txt */"Alat",
   ItemRarityRare: /* csgo_indonesian.txt */"Kualitas Tinggi",
   ItemRarityUncommon: /* csgo_indonesian.txt */"Kualitas Menengah",
+  ItemSealedGraffiti: /* csgo_indonesian.txt */"Grafiti Tersegel",
   ItemSwapStatTrakAccept: /* csgo_indonesian.txt */"TERIMA",
   ItemSwapStatTrakClose: /* csgo_indonesian.txt */"Tutup",
   ItemSwapStatTrakDesc: /* csgo_indonesian.txt */"Item ini menukar nilai StatTrak™ antara dua jenis item yang sama.",

--- a/app/translations/indonesian.ts
+++ b/app/translations/indonesian.ts
@@ -225,6 +225,7 @@ export const indonesian = {
   InventorySelectInspectContents: /* csgo_indonesian.txt */"Memeriksa isi dari",
   InventorySelectItemToDeposit: /* csgo_indonesian.txt */"Pilih item untuk dipindahkan",
   InventorySelectItemToRetrieve: /* csgo_indonesian.txt */"Pilih item untuk diambil",
+  ItemGraffitiChargesRemaining: /* csgo_indonesian.txt */"Sisa: {1}",
   ItemRarityAncient: /* csgo_indonesian.txt */"Fantastis",
   ItemRarityCommon: /* csgo_indonesian.txt */"Kualitas Biasa",
   ItemRarityDefault: /* csgo_indonesian.txt */"Default",

--- a/app/translations/indonesian.ts
+++ b/app/translations/indonesian.ts
@@ -216,6 +216,7 @@ export const indonesian = {
   InventoryItemUnequipCT: "Lepas CT",
   InventoryItemUnequipT: "Lepas T",
   InventoryItemUnlockContainer: /* csgo_indonesian.txt */"Buka Kontainer",
+  InventoryItemUnsealGraffiti: /* csgo_indonesian.txt */"Buka dan Pasang",
   InventoryItemUseItem: /* csgo_indonesian.txt */"Gunakan Item",
   InventoryItemUseStorageUnit: /* csgo_indonesian.txt */"Mulai Gunakan Unit Ini",
   InventoryItemWear: "Kondisi:",
@@ -343,5 +344,10 @@ export const indonesian = {
   UnpackClose: /* csgo_indonesian.txt */"Tutup",
   UnpackDesc: /* csgo_indonesian.txt */"Apa kamu yakin ingin membuka item ini?",
   UnpackNumberOfItems: /* csgo_indonesian.txt */"Jumlah Item: {1}",
-  UnpackTitle: /* csgo_indonesian.txt */"Buka {1}"
+  UnpackTitle: /* csgo_indonesian.txt */"Buka {1}",
+  UnsealGraffitiClose: /* csgo_indonesian.txt */"Tutup",
+  UnsealGraffitiDesc: /* csgo_indonesian.txt */"Buka",
+  UnsealGraffitiTitle: /* csgo_indonesian.txt */"Buka Grafiti",
+  UnsealGraffitiUse: /* csgo_indonesian.txt */"Buka Segel Grafiti",
+  UnsealGraffitiWarn: /* csgo_indonesian.txt */"Segel grafiti ini hanya bisa dibuka satu kali"
 };

--- a/app/translations/italian.ts
+++ b/app/translations/italian.ts
@@ -257,6 +257,7 @@ export const italian = {
   ItemRarityRare: /* csgo_italian.txt */"Qualità elevata",
   ItemRarityUncommon: /* csgo_italian.txt */"Qualità media",
   ItemSealedGraffiti: /* csgo_italian.txt */"Graffito sigillato",
+  ItemSealedGraffitiDesc: /* csgo_italian.txt */"Un contenitore sigillato con un motivo per graffiti. Una volta sbloccato questo motivo, otterrai abbastanza utilizzi da applicare il graffito per 50 volte nell'ambiente di gioco.",
   ItemSwapStatTrakAccept: /* csgo_italian.txt */"ACCETTA",
   ItemSwapStatTrakClose: /* csgo_italian.txt */"Chiudi",
   ItemSwapStatTrakDesc: /* csgo_italian.txt */"Questo oggetto scambia i valori dei contatori StatTrak™ di due oggetti dello stesso tipo.",

--- a/app/translations/italian.ts
+++ b/app/translations/italian.ts
@@ -256,6 +256,7 @@ export const italian = {
   ItemRarityNameTool: /* csgo_italian.txt */"Strumento",
   ItemRarityRare: /* csgo_italian.txt */"Qualità elevata",
   ItemRarityUncommon: /* csgo_italian.txt */"Qualità media",
+  ItemSealedGraffiti: /* csgo_italian.txt */"Graffito sigillato",
   ItemSwapStatTrakAccept: /* csgo_italian.txt */"ACCETTA",
   ItemSwapStatTrakClose: /* csgo_italian.txt */"Chiudi",
   ItemSwapStatTrakDesc: /* csgo_italian.txt */"Questo oggetto scambia i valori dei contatori StatTrak™ di due oggetti dello stesso tipo.",

--- a/app/translations/italian.ts
+++ b/app/translations/italian.ts
@@ -228,6 +228,7 @@ export const italian = {
   InventorySelectInspectContents: /* csgo_italian.txt */"Ispezione dei contenuti di",
   InventorySelectItemToDeposit: /* csgo_italian.txt */"Seleziona gli oggetti da spostare",
   InventorySelectItemToRetrieve: /* csgo_italian.txt */"Seleziona gli oggetti da recuperare dal",
+  ItemGraffitiChargesRemaining: /* csgo_italian.txt */"Utilizzi rimasti: {1}",
   ItemRarityAncient: /* csgo_italian.txt */"Straordinario",
   ItemRarityCommon: /* csgo_italian.txt */"Qualità base",
   ItemRarityDefault: /* csgo_italian.txt */"Predefinito",

--- a/app/translations/italian.ts
+++ b/app/translations/italian.ts
@@ -219,6 +219,7 @@ export const italian = {
   InventoryItemUnequipCT: "Rimuovi CT",
   InventoryItemUnequipT: "Rimuovi T",
   InventoryItemUnlockContainer: /* csgo_italian.txt */"Sblocca la cassa",
+  InventoryItemUnsealGraffiti: /* csgo_italian.txt */"Apri ed equipaggia",
   InventoryItemUseItem: /* csgo_italian.txt */"Usa oggetto",
   InventoryItemUseStorageUnit: /* csgo_italian.txt */"Inizia ad usare questa unità",
   InventoryItemWear: "Condizioni:",
@@ -346,5 +347,10 @@ export const italian = {
   UnpackClose: /* csgo_italian.txt */"Chiudi",
   UnpackDesc: /* csgo_italian.txt */"Vuoi davvero aprire questo oggetto?",
   UnpackNumberOfItems: /* csgo_italian.txt */"Numero di oggetti: {1}",
-  UnpackTitle: /* csgo_italian.txt */"Apri {1}"
+  UnpackTitle: /* csgo_italian.txt */"Apri {1}",
+  UnsealGraffitiClose: /* csgo_italian.txt */"Chiudi",
+  UnsealGraffitiDesc: /* csgo_italian.txt */"Apri",
+  UnsealGraffitiTitle: /* csgo_italian.txt */"Apri graffito",
+  UnsealGraffitiUse: /* csgo_italian.txt */"Apri graffito",
+  UnsealGraffitiWarn: /* csgo_italian.txt */"Questo graffito può essere aperto solo una volta"
 };

--- a/app/translations/japanese.ts
+++ b/app/translations/japanese.ts
@@ -219,6 +219,7 @@ export const japanese = {
   InventoryItemUnequipCT: "CTの装備解除",
   InventoryItemUnequipT: "Tの装備解除",
   InventoryItemUnlockContainer: /* csgo_japanese.txt */"コンテナを開ける",
+  InventoryItemUnsealGraffiti: /* csgo_japanese.txt */"開封して装備する",
   InventoryItemUseItem: /* csgo_japanese.txt */"アイテムを使用",
   InventoryItemUseStorageUnit: /* csgo_japanese.txt */"このユニットを使い始める",
   InventoryItemWear: "損耗:",
@@ -346,5 +347,10 @@ export const japanese = {
   UnpackClose: /* csgo_japanese.txt */"閉じる",
   UnpackDesc: /* csgo_japanese.txt */"本当にこのアイテムを開封しますか？",
   UnpackNumberOfItems: /* csgo_japanese.txt */"アイテム数: {1}",
-  UnpackTitle: /* csgo_japanese.txt */"{1}を開封"
+  UnpackTitle: /* csgo_japanese.txt */"{1}を開封",
+  UnsealGraffitiClose: /* csgo_japanese.txt */"閉じる",
+  UnsealGraffitiDesc: /* csgo_japanese.txt */"を開ける",
+  UnsealGraffitiTitle: /* csgo_japanese.txt */"グラフィティを開封する",
+  UnsealGraffitiUse: /* csgo_japanese.txt */"グラフィティを開封する",
+  UnsealGraffitiWarn: /* csgo_japanese.txt */"このグラフィティは一度しか開封できません"
 };

--- a/app/translations/japanese.ts
+++ b/app/translations/japanese.ts
@@ -228,6 +228,7 @@ export const japanese = {
   InventorySelectInspectContents: /* csgo_japanese.txt */"中身を確認中",
   InventorySelectItemToDeposit: /* csgo_japanese.txt */"移動させるアイテムを選択",
   InventorySelectItemToRetrieve: /* csgo_japanese.txt */"取り出すアイテムを選択",
+  ItemGraffitiChargesRemaining: /* csgo_japanese.txt */"チャージ残量: {1}",
   ItemRarityAncient: /* csgo_japanese.txt */"レア",
   ItemRarityCommon: /* csgo_japanese.txt */"ベースグレード",
   ItemRarityDefault: /* csgo_japanese.txt */"デフォルト",

--- a/app/translations/japanese.ts
+++ b/app/translations/japanese.ts
@@ -256,6 +256,7 @@ export const japanese = {
   ItemRarityNameTool: /* csgo_japanese.txt */"ツール",
   ItemRarityRare: /* csgo_japanese.txt */"ハイグレード",
   ItemRarityUncommon: /* csgo_japanese.txt */"ミディアムグレード",
+  ItemSealedGraffiti: /* csgo_japanese.txt */"未開封グラフィティ",
   ItemSwapStatTrakAccept: /* csgo_japanese.txt */"了解",
   ItemSwapStatTrakClose: /* csgo_japanese.txt */"閉じる",
   ItemSwapStatTrakDesc: /* csgo_japanese.txt */"同じタイプのアイテム間で StatTrak™ の値を入れ替えるツールです。",

--- a/app/translations/japanese.ts
+++ b/app/translations/japanese.ts
@@ -257,6 +257,7 @@ export const japanese = {
   ItemRarityRare: /* csgo_japanese.txt */"ハイグレード",
   ItemRarityUncommon: /* csgo_japanese.txt */"ミディアムグレード",
   ItemSealedGraffiti: /* csgo_japanese.txt */"未開封グラフィティ",
+  ItemSealedGraffitiDesc: /* csgo_japanese.txt */"グラフィティが入った未開封のコンテナです。開封したグラフィティには50回分のチャージがあり、チャージの数だけゲーム内でグラフィティを適用できます。",
   ItemSwapStatTrakAccept: /* csgo_japanese.txt */"了解",
   ItemSwapStatTrakClose: /* csgo_japanese.txt */"閉じる",
   ItemSwapStatTrakDesc: /* csgo_japanese.txt */"同じタイプのアイテム間で StatTrak™ の値を入れ替えるツールです。",

--- a/app/translations/koreana.ts
+++ b/app/translations/koreana.ts
@@ -229,6 +229,7 @@ export const koreana = {
   InventorySelectInspectContents: /* csgo_koreana.txt */"관찰 중인 저장 컨테이너:",
   InventorySelectItemToDeposit: /* csgo_koreana.txt */"다음 저장 컨테이너로 이동할 아이템 선택:",
   InventorySelectItemToRetrieve: /* csgo_koreana.txt */"다음 저장 컨테이너에서 가져올 아이템 선택:",
+  ItemGraffitiChargesRemaining: /* csgo_koreana.txt */"남은 사용 횟수: {1}번",
   ItemRarityAncient: /* csgo_koreana.txt */"희귀",
   ItemRarityCommon: /* csgo_koreana.txt */"일반",
   ItemRarityDefault: /* csgo_koreana.txt */"기본",

--- a/app/translations/koreana.ts
+++ b/app/translations/koreana.ts
@@ -257,6 +257,7 @@ export const koreana = {
   ItemRarityNameTool: /* csgo_koreana.txt */"도구",
   ItemRarityRare: /* csgo_koreana.txt */"고급",
   ItemRarityUncommon: /* csgo_koreana.txt */"중급",
+  ItemSealedGraffiti: /* csgo_koreana.txt */"개봉 안 한 그래피티",
   ItemSwapStatTrakAccept: /* csgo_koreana.txt */"수락",
   ItemSwapStatTrakClose: /* csgo_koreana.txt */"닫기",
   ItemSwapStatTrakDesc: /* csgo_koreana.txt */"이 아이템으로 유형이 같은 두 아이템의 StatTrak™ 점수를 맞바꿀 수 있습니다.",

--- a/app/translations/koreana.ts
+++ b/app/translations/koreana.ts
@@ -220,6 +220,7 @@ export const koreana = {
   InventoryItemUnequipCT: "CT 장착 해제",
   InventoryItemUnequipT: "T 장착 해제",
   InventoryItemUnlockContainer: /* csgo_koreana.txt */"상자 열기",
+  InventoryItemUnsealGraffiti: /* csgo_koreana.txt */"개봉 후 장착",
   InventoryItemUseItem: /* csgo_koreana.txt */"아이템 사용",
   InventoryItemUseStorageUnit: /* csgo_koreana.txt */"저장 컨테이너 사용",
   InventoryItemWear: "형태:",
@@ -347,5 +348,10 @@ export const koreana = {
   UnpackClose: /* csgo_koreana.txt */"닫기",
   UnpackDesc: /* csgo_koreana.txt */"이 아이템을 개봉할까요?",
   UnpackNumberOfItems: /* csgo_koreana.txt */"아이템 개수: {1}",
-  UnpackTitle: /* csgo_koreana.txt */"{1} 아이템 개봉"
+  UnpackTitle: /* csgo_koreana.txt */"{1} 아이템 개봉",
+  UnsealGraffitiClose: /* csgo_koreana.txt */"닫기",
+  UnsealGraffitiDesc: /* csgo_koreana.txt */"열기",
+  UnsealGraffitiTitle: /* csgo_koreana.txt */"그래피티 열기",
+  UnsealGraffitiUse: /* csgo_koreana.txt */"미개봉 그래피티",
+  UnsealGraffitiWarn: /* csgo_koreana.txt */"이 그래피티는 한 번만 개봉할 수 있습니다."
 };

--- a/app/translations/koreana.ts
+++ b/app/translations/koreana.ts
@@ -258,6 +258,7 @@ export const koreana = {
   ItemRarityRare: /* csgo_koreana.txt */"고급",
   ItemRarityUncommon: /* csgo_koreana.txt */"중급",
   ItemSealedGraffiti: /* csgo_koreana.txt */"개봉 안 한 그래피티",
+  ItemSealedGraffitiDesc: /* csgo_koreana.txt */"아직 개봉하지 않은 그래피티 패턴입니다. 이 그래피티 패턴을 개봉하면 게임에서 그래피티 패턴을 50번 남길 수 있습니다.",
   ItemSwapStatTrakAccept: /* csgo_koreana.txt */"수락",
   ItemSwapStatTrakClose: /* csgo_koreana.txt */"닫기",
   ItemSwapStatTrakDesc: /* csgo_koreana.txt */"이 아이템으로 유형이 같은 두 아이템의 StatTrak™ 점수를 맞바꿀 수 있습니다.",

--- a/app/translations/latam.ts
+++ b/app/translations/latam.ts
@@ -257,6 +257,7 @@ export const latam = {
   ItemRarityNameTool: /* csgo_latam.txt */"Herramienta",
   ItemRarityRare: /* csgo_latam.txt */"de grado alto",
   ItemRarityUncommon: /* csgo_latam.txt */"de grado medio",
+  ItemSealedGraffiti: /* csgo_latam.txt */"Grafiti precintado",
   ItemSwapStatTrakAccept: /* csgo_latam.txt */"ACEPTAR",
   ItemSwapStatTrakClose: /* csgo_latam.txt */"Cerrar",
   ItemSwapStatTrakDesc: /* csgo_latam.txt */"Este objeto intercambia los valores StatTrak™ entre dos artículos del mismo tipo.",

--- a/app/translations/latam.ts
+++ b/app/translations/latam.ts
@@ -229,6 +229,7 @@ export const latam = {
   InventorySelectInspectContents: /* csgo_latam.txt */"Revisando el contenido de",
   InventorySelectItemToDeposit: /* csgo_latam.txt */"Selecciona los artículos que deseas recuperar de",
   InventorySelectItemToRetrieve: /* csgo_latam.txt */"Selecciona los artículos que deseas recuperar de",
+  ItemGraffitiChargesRemaining: /* csgo_latam.txt */"Cargas restantes: {1}",
   ItemRarityAncient: /* csgo_latam.txt */"de aspecto extraordinario",
   ItemRarityCommon: /* csgo_latam.txt */"de grado básico",
   ItemRarityDefault: /* csgo_latam.txt */"estándar",

--- a/app/translations/latam.ts
+++ b/app/translations/latam.ts
@@ -220,6 +220,7 @@ export const latam = {
   InventoryItemUnequipCT: "Desequipar CT",
   InventoryItemUnequipT: "Desequipar T",
   InventoryItemUnlockContainer: /* csgo_latam.txt */"Abrir paquete",
+  InventoryItemUnsealGraffiti: /* csgo_latam.txt */"Abrir y equipar",
   InventoryItemUseItem: /* csgo_latam.txt */"Usar objeto",
   InventoryItemUseStorageUnit: /* csgo_latam.txt */"Comenzar a usar esta unidad",
   InventoryItemWear: "Desgaste:",
@@ -347,5 +348,10 @@ export const latam = {
   UnpackClose: /* csgo_latam.txt */"Cerrar",
   UnpackDesc: /* csgo_latam.txt */"¿Seguro que quieres abrir este artículo?",
   UnpackNumberOfItems: /* csgo_latam.txt */"Cantidad de artículos: {1}",
-  UnpackTitle: /* csgo_latam.txt */"Abrir {1}"
+  UnpackTitle: /* csgo_latam.txt */"Abrir {1}",
+  UnsealGraffitiClose: /* csgo_latam.txt */"Cerrar",
+  UnsealGraffitiDesc: /* csgo_latam.txt */"Abrir",
+  UnsealGraffitiTitle: /* csgo_latam.txt */"Abrir grafiti",
+  UnsealGraffitiUse: /* csgo_latam.txt */"Abrir grafiti",
+  UnsealGraffitiWarn: /* csgo_latam.txt */"Este grafiti solo se puede abrir una vez"
 };

--- a/app/translations/latam.ts
+++ b/app/translations/latam.ts
@@ -258,6 +258,7 @@ export const latam = {
   ItemRarityRare: /* csgo_latam.txt */"de grado alto",
   ItemRarityUncommon: /* csgo_latam.txt */"de grado medio",
   ItemSealedGraffiti: /* csgo_latam.txt */"Grafiti precintado",
+  ItemSealedGraffitiDesc: /* csgo_latam.txt */"Esto es un contenedor precintado de un patrón de grafiti. Al abrirlo obtendrás cargas suficientes para hacer el grafiti 50 veces en el mundo del juego.",
   ItemSwapStatTrakAccept: /* csgo_latam.txt */"ACEPTAR",
   ItemSwapStatTrakClose: /* csgo_latam.txt */"Cerrar",
   ItemSwapStatTrakDesc: /* csgo_latam.txt */"Este objeto intercambia los valores StatTrak™ entre dos artículos del mismo tipo.",

--- a/app/translations/norwegian.ts
+++ b/app/translations/norwegian.ts
@@ -255,6 +255,7 @@ export const norwegian = {
   ItemRarityNameTool: /* csgo_norwegian.txt */"Verktøy",
   ItemRarityRare: /* csgo_norwegian.txt */"Høy klasse",
   ItemRarityUncommon: /* csgo_norwegian.txt */"Mellomklasse",
+  ItemSealedGraffiti: /* csgo_norwegian.txt */"Forseglet graffiti",
   ItemSwapStatTrakAccept: /* csgo_norwegian.txt */"GODTA",
   ItemSwapStatTrakClose: /* csgo_norwegian.txt */"Lukk",
   ItemSwapStatTrakDesc: /* csgo_norwegian.txt */"Denne gjenstanden bytter StatTrak™-verdier mellom to gjenstander av samme type.",

--- a/app/translations/norwegian.ts
+++ b/app/translations/norwegian.ts
@@ -256,6 +256,7 @@ export const norwegian = {
   ItemRarityRare: /* csgo_norwegian.txt */"Høy klasse",
   ItemRarityUncommon: /* csgo_norwegian.txt */"Mellomklasse",
   ItemSealedGraffiti: /* csgo_norwegian.txt */"Forseglet graffiti",
+  ItemSealedGraffitiDesc: /* csgo_norwegian.txt */"Dette er en forseglet beholder med et graffitimønster. Når forseglingen brytes, har den nok innhold til å påføre graffitimønsteret 50 ganger i spillverdenen.",
   ItemSwapStatTrakAccept: /* csgo_norwegian.txt */"GODTA",
   ItemSwapStatTrakClose: /* csgo_norwegian.txt */"Lukk",
   ItemSwapStatTrakDesc: /* csgo_norwegian.txt */"Denne gjenstanden bytter StatTrak™-verdier mellom to gjenstander av samme type.",

--- a/app/translations/norwegian.ts
+++ b/app/translations/norwegian.ts
@@ -227,6 +227,7 @@ export const norwegian = {
   InventorySelectInspectContents: /* csgo_norwegian.txt */"Inspiserer innholdet i",
   InventorySelectItemToDeposit: /* csgo_norwegian.txt */"Velg gjenstander du vil oppbevare i",
   InventorySelectItemToRetrieve: /* csgo_norwegian.txt */"Velg gjenstander du vil hente fra",
+  ItemGraffitiChargesRemaining: /* csgo_norwegian.txt */"Ladninger igjen: {1}",
   ItemRarityAncient: /* csgo_norwegian.txt */"Ekstraordinær",
   ItemRarityCommon: /* csgo_norwegian.txt */"Vanlig",
   ItemRarityDefault: /* csgo_norwegian.txt */"Standard",

--- a/app/translations/norwegian.ts
+++ b/app/translations/norwegian.ts
@@ -218,6 +218,7 @@ export const norwegian = {
   InventoryItemUnequipCT: "Fjern utstyr CT",
   InventoryItemUnequipT: "Fjern utstyr T",
   InventoryItemUnlockContainer: /* csgo_norwegian.txt */"Lås opp beholder",
+  InventoryItemUnsealGraffiti: /* csgo_norwegian.txt */"Åpne og utstyr",
   InventoryItemUseItem: /* csgo_norwegian.txt */"Bruk gjenstand",
   InventoryItemUseStorageUnit: /* csgo_norwegian.txt */"Begynn å bruke denne enheten",
   InventoryItemWear: "Slitasje:",
@@ -345,5 +346,10 @@ export const norwegian = {
   UnpackClose: /* csgo_norwegian.txt */"Lukk",
   UnpackDesc: /* csgo_norwegian.txt */"Er du sikker på at du vil pakke opp denne gjenstanden?",
   UnpackNumberOfItems: /* csgo_norwegian.txt */"Antall gjenstander: {1}",
-  UnpackTitle: /* csgo_norwegian.txt */"Pakk opp {1}"
+  UnpackTitle: /* csgo_norwegian.txt */"Pakk opp {1}",
+  UnsealGraffitiClose: /* csgo_norwegian.txt */"Lukk",
+  UnsealGraffitiDesc: /* csgo_norwegian.txt */"Åpne",
+  UnsealGraffitiTitle: /* csgo_norwegian.txt */"Åpne graffiti",
+  UnsealGraffitiUse: /* csgo_norwegian.txt */"Åpne graffiti",
+  UnsealGraffitiWarn: /* csgo_norwegian.txt */"Denne graffitien kan kun åpnes én gang"
 };

--- a/app/translations/polish.ts
+++ b/app/translations/polish.ts
@@ -219,6 +219,7 @@ export const polish = {
   InventoryItemUnequipCT: "Przestań używać w CT",
   InventoryItemUnequipT: "Przestań używać w T",
   InventoryItemUnlockContainer: /* csgo_polish.txt */"Otwórz pojemnik",
+  InventoryItemUnsealGraffiti: /* csgo_polish.txt */"Otwórz i użyj",
   InventoryItemUseItem: /* csgo_polish.txt */"Użyj przedmiotu",
   InventoryItemUseStorageUnit: /* csgo_polish.txt */"Zacznij korzystać z tego magazynu",
   InventoryItemWear: "Zużycie:",
@@ -346,5 +347,10 @@ export const polish = {
   UnpackClose: /* csgo_polish.txt */"Zamknij",
   UnpackDesc: /* csgo_polish.txt */"Czy na pewno chcesz odpakować ten przedmiot?",
   UnpackNumberOfItems: /* csgo_polish.txt */"Liczba przedmiotów: {1}",
-  UnpackTitle: /* csgo_polish.txt */"Odpakuj: {1}"
+  UnpackTitle: /* csgo_polish.txt */"Odpakuj: {1}",
+  UnsealGraffitiClose: /* csgo_polish.txt */"Zamknij",
+  UnsealGraffitiDesc: /* csgo_polish.txt */"Otwórz:",
+  UnsealGraffitiTitle: /* csgo_polish.txt */"Otwórz graffiti",
+  UnsealGraffitiUse: /* csgo_polish.txt */"Odlakuj graffiti",
+  UnsealGraffitiWarn: /* csgo_polish.txt */"To graffiti może zostać odlakowane tylko raz"
 };

--- a/app/translations/polish.ts
+++ b/app/translations/polish.ts
@@ -257,6 +257,7 @@ export const polish = {
   ItemRarityRare: /* csgo_polish.txt */"wysokiej jakości",
   ItemRarityUncommon: /* csgo_polish.txt */"Średniej jakości",
   ItemSealedGraffiti: /* csgo_polish.txt */"Zalakowane graffiti",
+  ItemSealedGraffitiDesc: /* csgo_polish.txt */"Zalakowany wzór graffiti. Po odlakowaniu będzie można go użyć 50 razy w świecie gry.",
   ItemSwapStatTrakAccept: /* csgo_polish.txt */"AKCEPTUJ",
   ItemSwapStatTrakClose: /* csgo_polish.txt */"Zamknij",
   ItemSwapStatTrakDesc: /* csgo_polish.txt */"Ten przedmiot zamienia wartości liczników StatTrak™ między przedmiotami tego samego rodzaju.",

--- a/app/translations/polish.ts
+++ b/app/translations/polish.ts
@@ -228,6 +228,7 @@ export const polish = {
   InventorySelectInspectContents: /* csgo_polish.txt */"Sprawdzanie zawartości:",
   InventorySelectItemToDeposit: /* csgo_polish.txt */"Wybierz przedmioty do zdeponowania",
   InventorySelectItemToRetrieve: /* csgo_polish.txt */"Wybierz przedmioty do odzyskania",
+  ItemGraffitiChargesRemaining: /* csgo_polish.txt */"Możliwe użycia: {1}",
   ItemRarityAncient: /* csgo_polish.txt */"wyjątkowej jakości",
   ItemRarityCommon: /* csgo_polish.txt */"standardowej jakości",
   ItemRarityDefault: /* csgo_polish.txt */"(standardowe wyposażenie)",

--- a/app/translations/polish.ts
+++ b/app/translations/polish.ts
@@ -256,6 +256,7 @@ export const polish = {
   ItemRarityNameTool: /* csgo_polish.txt */"Narzędzie",
   ItemRarityRare: /* csgo_polish.txt */"wysokiej jakości",
   ItemRarityUncommon: /* csgo_polish.txt */"Średniej jakości",
+  ItemSealedGraffiti: /* csgo_polish.txt */"Zalakowane graffiti",
   ItemSwapStatTrakAccept: /* csgo_polish.txt */"AKCEPTUJ",
   ItemSwapStatTrakClose: /* csgo_polish.txt */"Zamknij",
   ItemSwapStatTrakDesc: /* csgo_polish.txt */"Ten przedmiot zamienia wartości liczników StatTrak™ między przedmiotami tego samego rodzaju.",

--- a/app/translations/portuguese.ts
+++ b/app/translations/portuguese.ts
@@ -258,6 +258,7 @@ export const portuguese = {
   ItemRarityRare: /* csgo_portuguese.txt */"Alta Qualidade",
   ItemRarityUncommon: /* csgo_portuguese.txt */"Qualidade Média",
   ItemSealedGraffiti: /* csgo_portuguese.txt */"Grafíti selado",
+  ItemSealedGraffitiDesc: /* csgo_portuguese.txt */"Uma caixa selada que contém um padrão de grafíti. Assim que esta caixa for aberta, poderás aplicar o grafíti 50 vezes em superfícies planas durante partidas em qualquer mapa.",
   ItemSwapStatTrakAccept: /* csgo_portuguese.txt */"ACEITAR",
   ItemSwapStatTrakClose: /* csgo_portuguese.txt */"Fechar",
   ItemSwapStatTrakDesc: /* csgo_portuguese.txt */"Este item troca as estatísticas StatTrak™ entre dois itens do mesmo tipo.",

--- a/app/translations/portuguese.ts
+++ b/app/translations/portuguese.ts
@@ -219,6 +219,7 @@ export const portuguese = {
   InventoryItemUnequipCT: "Desequipar CT",
   InventoryItemUnequipT: "Desequipar T",
   InventoryItemUnlockContainer: /* csgo_portuguese.txt */"Abrir",
+  InventoryItemUnsealGraffiti: /* csgo_portuguese.txt */"Abrir e equipar",
   InventoryItemUseItem: /* csgo_portuguese.txt */"Usar item",
   InventoryItemUseStorageUnit: /* csgo_portuguese.txt */"Usar esta unidade",
   InventoryItemWear: "Desgaste:",
@@ -347,5 +348,10 @@ export const portuguese = {
   UnpackClose: /* csgo_portuguese.txt */"Fechar",
   UnpackDesc: /* csgo_portuguese.txt */"Tens a certeza de que queres abrir este item?",
   UnpackNumberOfItems: /* csgo_portuguese.txt */"Número de itens: {1}",
-  UnpackTitle: /* csgo_portuguese.txt */"Abrir {1}"
+  UnpackTitle: /* csgo_portuguese.txt */"Abrir {1}",
+  UnsealGraffitiClose: /* csgo_portuguese.txt */"Fechar",
+  UnsealGraffitiDesc: /* csgo_portuguese.txt */"Abrir",
+  UnsealGraffitiTitle: /* csgo_portuguese.txt */"Abrir grafíti",
+  UnsealGraffitiUse: /* csgo_portuguese.txt */"Abrir grafíti",
+  UnsealGraffitiWarn: /* csgo_portuguese.txt */"Este grafíti só pode ser aberto uma vez"
 };

--- a/app/translations/portuguese.ts
+++ b/app/translations/portuguese.ts
@@ -228,6 +228,7 @@ export const portuguese = {
   InventorySelectInspectContents: /* csgo_portuguese.txt */"A ver conteúdo de",
   InventorySelectItemToDeposit: /* csgo_portuguese.txt */"Seleciona quais itens guardar em",
   InventorySelectItemToRetrieve: /* csgo_portuguese.txt */"Seleciona quais itens retirar de",
+  ItemGraffitiChargesRemaining: /* csgo_portuguese.txt */"Utilizações restantes: {1}",
   ItemRarityAncient: /* csgo_portuguese.txt */"Extraordinário",
   ItemRarityCommon: /* csgo_portuguese.txt */"Qualidade Básica",
   ItemRarityDefault: /* csgo_portuguese.txt */"Standard",

--- a/app/translations/portuguese.ts
+++ b/app/translations/portuguese.ts
@@ -257,6 +257,7 @@ export const portuguese = {
   ItemRarityNameTool: /* csgo_portuguese.txt */"Ferramenta",
   ItemRarityRare: /* csgo_portuguese.txt */"Alta Qualidade",
   ItemRarityUncommon: /* csgo_portuguese.txt */"Qualidade Média",
+  ItemSealedGraffiti: /* csgo_portuguese.txt */"Grafíti selado",
   ItemSwapStatTrakAccept: /* csgo_portuguese.txt */"ACEITAR",
   ItemSwapStatTrakClose: /* csgo_portuguese.txt */"Fechar",
   ItemSwapStatTrakDesc: /* csgo_portuguese.txt */"Este item troca as estatísticas StatTrak™ entre dois itens do mesmo tipo.",

--- a/app/translations/romanian.ts
+++ b/app/translations/romanian.ts
@@ -219,6 +219,7 @@ export const romanian = {
   InventoryItemUnequipCT: "Dezechipează CT",
   InventoryItemUnequipT: "Dezechipează T",
   InventoryItemUnlockContainer: /* csgo_romanian.txt */"Deschide containerul",
+  InventoryItemUnsealGraffiti: /* csgo_romanian.txt */"Deschide și echipează",
   InventoryItemUseItem: /* csgo_romanian.txt */"Folosește obiectul",
   InventoryItemUseStorageUnit: /* csgo_romanian.txt */"Începe să folosești această unitate de depozitare",
   InventoryItemWear: "Uzură:",
@@ -346,5 +347,10 @@ export const romanian = {
   UnpackClose: /* csgo_romanian.txt */"Închide",
   UnpackDesc: /* csgo_romanian.txt */"Sigur vrei să despachetezi acest obiect?",
   UnpackNumberOfItems: /* csgo_romanian.txt */"Numărul de obiecte: {1}",
-  UnpackTitle: /* csgo_romanian.txt */"Despachetează: {1}"
+  UnpackTitle: /* csgo_romanian.txt */"Despachetează: {1}",
+  UnsealGraffitiClose: /* csgo_romanian.txt */"Închide",
+  UnsealGraffitiDesc: /* csgo_romanian.txt */"Deschide:",
+  UnsealGraffitiTitle: /* csgo_romanian.txt */"Deschide graffitiul",
+  UnsealGraffitiUse: /* csgo_romanian.txt */"Desigilează graffitiul",
+  UnsealGraffitiWarn: /* csgo_romanian.txt */"Acest graffiti poate fi desigilat doar o singură dată."
 };

--- a/app/translations/romanian.ts
+++ b/app/translations/romanian.ts
@@ -257,6 +257,7 @@ export const romanian = {
   ItemRarityRare: /* csgo_romanian.txt */"Calitate ridicată",
   ItemRarityUncommon: /* csgo_romanian.txt */"Calitate medie",
   ItemSealedGraffiti: /* csgo_romanian.txt */"Graffiti sigilat",
+  ItemSealedGraffitiDesc: /* csgo_romanian.txt */"Acesta este un container sigilat cu un model graffiti. Odată ce acest model graffiti este desigilat, îți va oferi suficiente folosiri pentru a aplica modelul graffiti de 50 de ori în lumea jocului.",
   ItemSwapStatTrakAccept: /* csgo_romanian.txt */"ACCEPTĂ",
   ItemSwapStatTrakClose: /* csgo_romanian.txt */"Închide",
   ItemSwapStatTrakDesc: /* csgo_romanian.txt */"Acest obiect schimbă între ele valorile StatTrak™ pentru două obiecte de același tip.",

--- a/app/translations/romanian.ts
+++ b/app/translations/romanian.ts
@@ -256,6 +256,7 @@ export const romanian = {
   ItemRarityNameTool: /* csgo_romanian.txt */"Instrument",
   ItemRarityRare: /* csgo_romanian.txt */"Calitate ridicată",
   ItemRarityUncommon: /* csgo_romanian.txt */"Calitate medie",
+  ItemSealedGraffiti: /* csgo_romanian.txt */"Graffiti sigilat",
   ItemSwapStatTrakAccept: /* csgo_romanian.txt */"ACCEPTĂ",
   ItemSwapStatTrakClose: /* csgo_romanian.txt */"Închide",
   ItemSwapStatTrakDesc: /* csgo_romanian.txt */"Acest obiect schimbă între ele valorile StatTrak™ pentru două obiecte de același tip.",

--- a/app/translations/romanian.ts
+++ b/app/translations/romanian.ts
@@ -228,6 +228,7 @@ export const romanian = {
   InventorySelectInspectContents: /* csgo_romanian.txt */"Inspectezi conținutul pentru:",
   InventorySelectItemToDeposit: /* csgo_romanian.txt */"Selecteză obiectele pe care să le depozitezi",
   InventorySelectItemToRetrieve: /* csgo_romanian.txt */"Selectează obiectele pe care să le preiei",
+  ItemGraffitiChargesRemaining: /* csgo_romanian.txt */"Aplicări rămase: {1}",
   ItemRarityAncient: /* csgo_romanian.txt */"Extraordinar(ă)",
   ItemRarityCommon: /* csgo_romanian.txt */"Calitate de bază",
   ItemRarityDefault: /* csgo_romanian.txt */"Implicit(ă)",

--- a/app/translations/russian.ts
+++ b/app/translations/russian.ts
@@ -256,6 +256,7 @@ export const russian = {
   ItemRarityNameTool: /* csgo_russian.txt */"Инструмент",
   ItemRarityRare: /* csgo_russian.txt */"высшего класса",
   ItemRarityUncommon: /* csgo_russian.txt */"Среднего класса",
+  ItemSealedGraffiti: /* csgo_russian.txt */"Запечатанный граффити",
   ItemSwapStatTrakAccept: /* csgo_russian.txt */"ПРИНЯТЬ",
   ItemSwapStatTrakClose: /* csgo_russian.txt */"Закрыть",
   ItemSwapStatTrakDesc: /* csgo_russian.txt */"Этот предмет может обменять значения StatTrak™ у двух одинаковых раскрасок предмета.",

--- a/app/translations/russian.ts
+++ b/app/translations/russian.ts
@@ -257,6 +257,7 @@ export const russian = {
   ItemRarityRare: /* csgo_russian.txt */"высшего класса",
   ItemRarityUncommon: /* csgo_russian.txt */"Среднего класса",
   ItemSealedGraffiti: /* csgo_russian.txt */"Запечатанный граффити",
+  ItemSealedGraffitiDesc: /* csgo_russian.txt */"Это запечатанный контейнер с шаблоном граффити. После вскрытия шаблона вы получите возможность применить его в игровом мире 50 раз.",
   ItemSwapStatTrakAccept: /* csgo_russian.txt */"ПРИНЯТЬ",
   ItemSwapStatTrakClose: /* csgo_russian.txt */"Закрыть",
   ItemSwapStatTrakDesc: /* csgo_russian.txt */"Этот предмет может обменять значения StatTrak™ у двух одинаковых раскрасок предмета.",

--- a/app/translations/russian.ts
+++ b/app/translations/russian.ts
@@ -228,6 +228,7 @@ export const russian = {
   InventorySelectInspectContents: /* csgo_russian.txt */"Просмотр содержимого:",
   InventorySelectItemToDeposit: /* csgo_russian.txt */"Убрать в хранилище:",
   InventorySelectItemToRetrieve: /* csgo_russian.txt */"Извлечь предметы:",
+  ItemGraffitiChargesRemaining: /* csgo_russian.txt */"Зарядов: {1}",
   ItemRarityAncient: /* csgo_russian.txt */"экстраординарного типа",
   ItemRarityCommon: /* csgo_russian.txt */"базового класса",
   ItemRarityDefault: /* csgo_russian.txt */"Стандартное",

--- a/app/translations/russian.ts
+++ b/app/translations/russian.ts
@@ -219,6 +219,7 @@ export const russian = {
   InventoryItemUnequipCT: "Снять за спецназ",
   InventoryItemUnequipT: "Снять за террористов",
   InventoryItemUnlockContainer: /* csgo_russian.txt */"Открыть контейнер",
+  InventoryItemUnsealGraffiti: /* csgo_russian.txt */"Использовать",
   InventoryItemUseItem: /* csgo_russian.txt */"Использовать предмет",
   InventoryItemUseStorageUnit: /* csgo_russian.txt */"Активировать хранилище",
   InventoryItemWear: "Износ:",
@@ -346,5 +347,10 @@ export const russian = {
   UnpackClose: /* csgo_russian.txt */"Закрыть",
   UnpackDesc: /* csgo_russian.txt */"Вы уверены, что хотите распаковать этот предмет?",
   UnpackNumberOfItems: /* csgo_russian.txt */"Число предметов: {1}",
-  UnpackTitle: /* csgo_russian.txt */"Распаковка: {1}"
+  UnpackTitle: /* csgo_russian.txt */"Распаковка: {1}",
+  UnsealGraffitiClose: /* csgo_russian.txt */"Закрыть",
+  UnsealGraffitiDesc: /* csgo_russian.txt */"Открыть",
+  UnsealGraffitiTitle: /* csgo_russian.txt */"Открыть граффити",
+  UnsealGraffitiUse: /* csgo_russian.txt */"Распечатать граффити",
+  UnsealGraffitiWarn: /* csgo_russian.txt */"Этот граффити можно распечатать только один раз"
 };

--- a/app/translations/schinese.ts
+++ b/app/translations/schinese.ts
@@ -220,6 +220,7 @@ export const schinese = {
   InventoryItemUnequipCT: "卸下反恐精英",
   InventoryItemUnequipT: "卸下恐怖分子",
   InventoryItemUnlockContainer: /* csgo_schinese.txt */"开箱",
+  InventoryItemUnsealGraffiti: /* csgo_schinese.txt */"开启并装备",
   InventoryItemUseItem: /* csgo_schinese.txt */"使用物品",
   InventoryItemUseStorageUnit: /* csgo_schinese.txt */"开始使用此组件",
   InventoryItemWear: "磨损:",
@@ -347,5 +348,10 @@ export const schinese = {
   UnpackClose: /* csgo_schinese.txt */"关闭",
   UnpackDesc: /* csgo_schinese.txt */"你确定要打开此物品吗？",
   UnpackNumberOfItems: /* csgo_schinese.txt */"物品数量: {1}",
-  UnpackTitle: /* csgo_schinese.txt */"打开{1}"
+  UnpackTitle: /* csgo_schinese.txt */"打开{1}",
+  UnsealGraffitiClose: /* csgo_schinese.txt */"关闭",
+  UnsealGraffitiDesc: /* csgo_schinese.txt */"开启",
+  UnsealGraffitiTitle: /* csgo_schinese.txt */"开启涂鸦",
+  UnsealGraffitiUse: /* csgo_schinese.txt */"启封涂鸦",
+  UnsealGraffitiWarn: /* csgo_schinese.txt */"该涂鸦仅可被启封一次"
 };

--- a/app/translations/schinese.ts
+++ b/app/translations/schinese.ts
@@ -257,6 +257,7 @@ export const schinese = {
   ItemRarityNameTool: /* csgo_schinese.txt */"工具",
   ItemRarityRare: /* csgo_schinese.txt */"高级",
   ItemRarityUncommon: /* csgo_schinese.txt */"中级",
+  ItemSealedGraffiti: /* csgo_schinese.txt */"封装的涂鸦",
   ItemSwapStatTrakAccept: /* csgo_schinese.txt */"接受",
   ItemSwapStatTrakClose: /* csgo_schinese.txt */"关闭",
   ItemSwapStatTrakDesc: /* csgo_schinese.txt */"该物品可以将两种相同物品类型的 StatTrak™ 数据互换。",

--- a/app/translations/schinese.ts
+++ b/app/translations/schinese.ts
@@ -229,6 +229,7 @@ export const schinese = {
   InventorySelectInspectContents: /* csgo_schinese.txt */"检视内容",
   InventorySelectItemToDeposit: /* csgo_schinese.txt */"选择物品以存入",
   InventorySelectItemToRetrieve: /* csgo_schinese.txt */"选择要取回的物品",
+  ItemGraffitiChargesRemaining: /* csgo_schinese.txt */"剩余次数：{1}",
   ItemRarityAncient: /* csgo_schinese.txt */"非凡",
   ItemRarityCommon: /* csgo_schinese.txt */"普通级",
   ItemRarityDefault: /* csgo_schinese.txt */"默认",

--- a/app/translations/schinese.ts
+++ b/app/translations/schinese.ts
@@ -258,6 +258,7 @@ export const schinese = {
   ItemRarityRare: /* csgo_schinese.txt */"高级",
   ItemRarityUncommon: /* csgo_schinese.txt */"中级",
   ItemSealedGraffiti: /* csgo_schinese.txt */"封装的涂鸦",
+  ItemSealedGraffitiDesc: /* csgo_schinese.txt */"这个罐子里封装着一个涂鸦图案。涂鸦一经开封，可以在游戏内喷涂 50 次。",
   ItemSwapStatTrakAccept: /* csgo_schinese.txt */"接受",
   ItemSwapStatTrakClose: /* csgo_schinese.txt */"关闭",
   ItemSwapStatTrakDesc: /* csgo_schinese.txt */"该物品可以将两种相同物品类型的 StatTrak™ 数据互换。",

--- a/app/translations/spanish.ts
+++ b/app/translations/spanish.ts
@@ -229,6 +229,7 @@ export const spanish = {
   InventorySelectInspectContents: /* csgo_spanish.txt */"Viendo el contenido de",
   InventorySelectItemToDeposit: /* csgo_spanish.txt */"Selecciona los artículos que deseas transferir a",
   InventorySelectItemToRetrieve: /* csgo_spanish.txt */"Selecciona los artículos que deseas recuperar de",
+  ItemGraffitiChargesRemaining: /* csgo_spanish.txt */"Cargas restantes: {1}",
   ItemRarityAncient: /* csgo_spanish.txt */"de aspecto extraordinario",
   ItemRarityCommon: /* csgo_spanish.txt */"de grado básico",
   ItemRarityDefault: /* csgo_spanish.txt */"por defecto",

--- a/app/translations/spanish.ts
+++ b/app/translations/spanish.ts
@@ -257,6 +257,7 @@ export const spanish = {
   ItemRarityNameTool: /* csgo_spanish.txt */"Herramienta",
   ItemRarityRare: /* csgo_spanish.txt */"de grado alto",
   ItemRarityUncommon: /* csgo_spanish.txt */"de grado medio",
+  ItemSealedGraffiti: /* csgo_spanish.txt */"Grafiti precintado",
   ItemSwapStatTrakAccept: /* csgo_spanish.txt */"ACEPTAR",
   ItemSwapStatTrakClose: /* csgo_spanish.txt */"Cerrar",
   ItemSwapStatTrakDesc: /* csgo_spanish.txt */"Este artículo intercambia los valores StatTrak™ entre dos artículos del mismo tipo.",

--- a/app/translations/spanish.ts
+++ b/app/translations/spanish.ts
@@ -220,6 +220,7 @@ export const spanish = {
   InventoryItemUnequipCT: "Desequipar antiterroristas",
   InventoryItemUnequipT: "Desequipar terroristas",
   InventoryItemUnlockContainer: /* csgo_spanish.txt */"Abrir paquete",
+  InventoryItemUnsealGraffiti: /* csgo_spanish.txt */"Abrir y equipar",
   InventoryItemUseItem: /* csgo_spanish.txt */"Usar artículo",
   InventoryItemUseStorageUnit: /* csgo_spanish.txt */"Comenzar a usar esta unidad",
   InventoryItemWear: "Desgaste:",
@@ -347,5 +348,10 @@ export const spanish = {
   UnpackClose: /* csgo_spanish.txt */"Cerrar",
   UnpackDesc: /* csgo_spanish.txt */"¿Seguro que quieres abrir este artículo?",
   UnpackNumberOfItems: /* csgo_spanish.txt */"Número de objetos: {1}",
-  UnpackTitle: /* csgo_spanish.txt */"Abrir {1}"
+  UnpackTitle: /* csgo_spanish.txt */"Abrir {1}",
+  UnsealGraffitiClose: /* csgo_spanish.txt */"Cerrar",
+  UnsealGraffitiDesc: /* csgo_spanish.txt */"Abrir",
+  UnsealGraffitiTitle: /* csgo_spanish.txt */"Abrir grafiti",
+  UnsealGraffitiUse: /* csgo_spanish.txt */"Abrir grafiti",
+  UnsealGraffitiWarn: /* csgo_spanish.txt */"Este grafiti solo se puede abrir una vez"
 };

--- a/app/translations/spanish.ts
+++ b/app/translations/spanish.ts
@@ -258,6 +258,7 @@ export const spanish = {
   ItemRarityRare: /* csgo_spanish.txt */"de grado alto",
   ItemRarityUncommon: /* csgo_spanish.txt */"de grado medio",
   ItemSealedGraffiti: /* csgo_spanish.txt */"Grafiti precintado",
+  ItemSealedGraffitiDesc: /* csgo_spanish.txt */"Esto es un contenedor precintado de un patrón de grafiti. Al abrirlo obtendrás cargas suficientes para hacer el grafiti 50 veces en el mundo del juego.",
   ItemSwapStatTrakAccept: /* csgo_spanish.txt */"ACEPTAR",
   ItemSwapStatTrakClose: /* csgo_spanish.txt */"Cerrar",
   ItemSwapStatTrakDesc: /* csgo_spanish.txt */"Este artículo intercambia los valores StatTrak™ entre dos artículos del mismo tipo.",

--- a/app/translations/swedish.ts
+++ b/app/translations/swedish.ts
@@ -228,6 +228,7 @@ export const swedish = {
   InventorySelectInspectContents: /* csgo_swedish.txt */"Inspekterar innehåll i",
   InventorySelectItemToDeposit: /* csgo_swedish.txt */"Välj föremål att lagra i",
   InventorySelectItemToRetrieve: /* csgo_swedish.txt */"Välj föremål att hämta från",
+  ItemGraffitiChargesRemaining: /* csgo_swedish.txt */"Återstående laddningar: {1}",
   ItemRarityAncient: /* csgo_swedish.txt */"Extraordinär",
   ItemRarityCommon: /* csgo_swedish.txt */"Grundkvalitet",
   ItemRarityDefault: /* csgo_swedish.txt */"Standard",

--- a/app/translations/swedish.ts
+++ b/app/translations/swedish.ts
@@ -256,6 +256,7 @@ export const swedish = {
   ItemRarityNameTool: /* csgo_swedish.txt */"Verktyg",
   ItemRarityRare: /* csgo_swedish.txt */"Högkvalitet",
   ItemRarityUncommon: /* csgo_swedish.txt */"Medelvärdig",
+  ItemSealedGraffiti: /* csgo_swedish.txt */"Förseglad graffiti",
   ItemSwapStatTrakAccept: /* csgo_swedish.txt */"ACCEPTERA",
   ItemSwapStatTrakClose: /* csgo_swedish.txt */"Stäng",
   ItemSwapStatTrakDesc: /* csgo_swedish.txt */"Detta föremål byter StatTrak™-värden mellan två likadana föremålstyper.",

--- a/app/translations/swedish.ts
+++ b/app/translations/swedish.ts
@@ -219,6 +219,7 @@ export const swedish = {
   InventoryItemUnequipCT: "Avutrusta CT",
   InventoryItemUnequipT: "Avutrusta T",
   InventoryItemUnlockContainer: /* csgo_swedish.txt */"Lås upp behållare",
+  InventoryItemUnsealGraffiti: /* csgo_swedish.txt */"Öppna och utrusta",
   InventoryItemUseItem: /* csgo_swedish.txt */"Använd föremål",
   InventoryItemUseStorageUnit: /* csgo_swedish.txt */"Börja använda denna enhet",
   InventoryItemWear: "Slitage:",
@@ -346,5 +347,10 @@ export const swedish = {
   UnpackClose: /* csgo_swedish.txt */"Stäng",
   UnpackDesc: /* csgo_swedish.txt */"Är du säker på att du vill packa upp detta föremål?",
   UnpackNumberOfItems: /* csgo_swedish.txt */"Antal föremål: {1}",
-  UnpackTitle: /* csgo_swedish.txt */"Packa upp {1}"
+  UnpackTitle: /* csgo_swedish.txt */"Packa upp {1}",
+  UnsealGraffitiClose: /* csgo_swedish.txt */"Stäng",
+  UnsealGraffitiDesc: /* csgo_swedish.txt */"Öppna",
+  UnsealGraffitiTitle: /* csgo_swedish.txt */"Öppna graffiti",
+  UnsealGraffitiUse: /* csgo_swedish.txt */"Öppna graffiti",
+  UnsealGraffitiWarn: /* csgo_swedish.txt */"Denna graffiti kan endast öppnas en gång"
 };

--- a/app/translations/swedish.ts
+++ b/app/translations/swedish.ts
@@ -257,6 +257,7 @@ export const swedish = {
   ItemRarityRare: /* csgo_swedish.txt */"Högkvalitet",
   ItemRarityUncommon: /* csgo_swedish.txt */"Medelvärdig",
   ItemSealedGraffiti: /* csgo_swedish.txt */"Förseglad graffiti",
+  ItemSealedGraffitiDesc: /* csgo_swedish.txt */"Det här är en förseglad behållare för ett graffitimönster. När behållaren har öppnats så kommer den ge dig tillräckligt med laddningar för att använda graffitimönstret 50 gånger i spelvärlden.",
   ItemSwapStatTrakAccept: /* csgo_swedish.txt */"ACCEPTERA",
   ItemSwapStatTrakClose: /* csgo_swedish.txt */"Stäng",
   ItemSwapStatTrakDesc: /* csgo_swedish.txt */"Detta föremål byter StatTrak™-värden mellan två likadana föremålstyper.",

--- a/app/translations/tchinese.ts
+++ b/app/translations/tchinese.ts
@@ -220,6 +220,7 @@ export const tchinese = {
   InventoryItemUnequipCT: "卸下反恐部隊",
   InventoryItemUnequipT: "卸下恐怖份子",
   InventoryItemUnlockContainer: /* csgo_tchinese.txt */"開啟箱子",
+  InventoryItemUnsealGraffiti: /* csgo_tchinese.txt */"開啟並裝備",
   InventoryItemUseItem: /* csgo_tchinese.txt */"使用物品",
   InventoryItemUseStorageUnit: /* csgo_tchinese.txt */"開始使用此儲存單元",
   InventoryItemWear: "磨損:",
@@ -347,5 +348,10 @@ export const tchinese = {
   UnpackClose: /* csgo_tchinese.txt */"關閉",
   UnpackDesc: /* csgo_tchinese.txt */"您確定要開封這項物品嗎？",
   UnpackNumberOfItems: /* csgo_tchinese.txt */"物品數量：{1}",
-  UnpackTitle: /* csgo_tchinese.txt */"開封「{1}」"
+  UnpackTitle: /* csgo_tchinese.txt */"開封「{1}」",
+  UnsealGraffitiClose: /* csgo_tchinese.txt */"關閉",
+  UnsealGraffitiDesc: /* csgo_tchinese.txt */"開啟",
+  UnsealGraffitiTitle: /* csgo_tchinese.txt */"開啟塗鴉",
+  UnsealGraffitiUse: /* csgo_tchinese.txt */"開封塗鴉",
+  UnsealGraffitiWarn: /* csgo_tchinese.txt */"此塗鴉僅可開封一次"
 };

--- a/app/translations/tchinese.ts
+++ b/app/translations/tchinese.ts
@@ -229,6 +229,7 @@ export const tchinese = {
   InventorySelectInspectContents: /* csgo_tchinese.txt */"檢視內容",
   InventorySelectItemToDeposit: /* csgo_tchinese.txt */"選擇物品以移入",
   InventorySelectItemToRetrieve: /* csgo_tchinese.txt */"選擇一項物品取回",
+  ItemGraffitiChargesRemaining: /* csgo_tchinese.txt */"剩餘使用次數：{1}",
   ItemRarityAncient: /* csgo_tchinese.txt */"超絕",
   ItemRarityCommon: /* csgo_tchinese.txt */"初級",
   ItemRarityDefault: /* csgo_tchinese.txt */"預設",

--- a/app/translations/tchinese.ts
+++ b/app/translations/tchinese.ts
@@ -258,6 +258,7 @@ export const tchinese = {
   ItemRarityRare: /* csgo_tchinese.txt */"高級",
   ItemRarityUncommon: /* csgo_tchinese.txt */"中階",
   ItemSealedGraffiti: /* csgo_tchinese.txt */"密封的塗鴉",
+  ItemSealedGraffitiDesc: /* csgo_tchinese.txt */"這是密封的塗鴉圖案。一旦開封後，會提供你 50 次將此塗鴉圖案用於遊戲內的機會。",
   ItemSwapStatTrakAccept: /* csgo_tchinese.txt */"接受",
   ItemSwapStatTrakClose: /* csgo_tchinese.txt */"關閉",
   ItemSwapStatTrakDesc: /* csgo_tchinese.txt */"此物品能夠交換兩項相同物品類型的 StatTrak™ 數值。",

--- a/app/translations/tchinese.ts
+++ b/app/translations/tchinese.ts
@@ -257,6 +257,7 @@ export const tchinese = {
   ItemRarityNameTool: /* csgo_tchinese.txt */"工具",
   ItemRarityRare: /* csgo_tchinese.txt */"高級",
   ItemRarityUncommon: /* csgo_tchinese.txt */"中階",
+  ItemSealedGraffiti: /* csgo_tchinese.txt */"密封的塗鴉",
   ItemSwapStatTrakAccept: /* csgo_tchinese.txt */"接受",
   ItemSwapStatTrakClose: /* csgo_tchinese.txt */"關閉",
   ItemSwapStatTrakDesc: /* csgo_tchinese.txt */"此物品能夠交換兩項相同物品類型的 StatTrak™ 數值。",

--- a/app/translations/thai.ts
+++ b/app/translations/thai.ts
@@ -220,6 +220,7 @@ export const thai = {
   InventoryItemUnequipCT: "ถอด CT",
   InventoryItemUnequipT: "ถอด T",
   InventoryItemUnlockContainer: /* csgo_thai.txt */"ปลดล็อคบรรจุภัณฑ์",
+  InventoryItemUnsealGraffiti: /* csgo_thai.txt */"เปิดและสวมใส่",
   InventoryItemUseItem: /* csgo_thai.txt */"ใช้ไอเท็ม",
   InventoryItemUseStorageUnit: /* csgo_thai.txt */"เริ่มใช้กล่องเก็บของนี้",
   InventoryItemWear: "ความเสื่อมสภาพ:",
@@ -347,5 +348,10 @@ export const thai = {
   UnpackClose: /* csgo_thai.txt */"ปิด",
   UnpackDesc: /* csgo_thai.txt */"คุณแน่ใจหรือไม่ว่าคุณต้องการแกะไอเท็มนี้?",
   UnpackNumberOfItems: /* csgo_thai.txt */"จำนวนของไอเท็ม: {1}",
-  UnpackTitle: /* csgo_thai.txt */"แกะ {1}"
+  UnpackTitle: /* csgo_thai.txt */"แกะ {1}",
+  UnsealGraffitiClose: /* csgo_thai.txt */"ปิด",
+  UnsealGraffitiDesc: /* csgo_thai.txt */"เปิด",
+  UnsealGraffitiTitle: /* csgo_thai.txt */"เปิดกราฟฟิตี้",
+  UnsealGraffitiUse: /* csgo_thai.txt */"เปิดผนึกกราฟฟิตี้",
+  UnsealGraffitiWarn: /* csgo_thai.txt */"กราฟฟิตี้นี้สามารถเปิดผนึกได้แค่ครั้งเดียวเท่านั้น"
 };

--- a/app/translations/thai.ts
+++ b/app/translations/thai.ts
@@ -229,6 +229,7 @@ export const thai = {
   InventorySelectInspectContents: /* csgo_thai.txt */"ตรวจสอบเนื้อหาของ",
   InventorySelectItemToDeposit: /* csgo_thai.txt */"เลือกไอเท็มเพื่อย้ายไปยัง",
   InventorySelectItemToRetrieve: /* csgo_thai.txt */"เลือกไอเท็มเพื่อเอาคืนจาก",
+  ItemGraffitiChargesRemaining: /* csgo_thai.txt */"ชาร์จคงเหลือ: {1}",
   ItemRarityAncient: /* csgo_thai.txt */"Extraordinary",
   ItemRarityCommon: /* csgo_thai.txt */"เกรดพื้นฐาน",
   ItemRarityDefault: /* csgo_thai.txt */"เริ่มต้น",

--- a/app/translations/thai.ts
+++ b/app/translations/thai.ts
@@ -258,6 +258,7 @@ export const thai = {
   ItemRarityRare: /* csgo_thai.txt */"เกรดสูง",
   ItemRarityUncommon: /* csgo_thai.txt */"เกรดปานกลาง",
   ItemSealedGraffiti: /* csgo_thai.txt */"กราฟฟิตี้แบบปิดผนึก",
+  ItemSealedGraffitiDesc: /* csgo_thai.txt */"นี่เป็นกล่องปิดผนึกของลายกราฟฟิตี้ เมื่อลายกราฟฟิตี้นี้ถูกเปิดผนึกแล้ว คุณจะได้รับชาร์จเพื่อนำไปใช้กับลายกราฟฟิตี้ 50 ครั้งเพื่อใช้ในเกม",
   ItemSwapStatTrakAccept: /* csgo_thai.txt */"ยอมรับ",
   ItemSwapStatTrakClose: /* csgo_thai.txt */"ปิด",
   ItemSwapStatTrakDesc: /* csgo_thai.txt */"ไอเท็มนี้จะสลับค่า StatTrak™ ระหว่างไอเท็มประเภทเดียวกันสองชิ้น",

--- a/app/translations/thai.ts
+++ b/app/translations/thai.ts
@@ -257,6 +257,7 @@ export const thai = {
   ItemRarityNameTool: /* csgo_thai.txt */"เครื่องมือ",
   ItemRarityRare: /* csgo_thai.txt */"เกรดสูง",
   ItemRarityUncommon: /* csgo_thai.txt */"เกรดปานกลาง",
+  ItemSealedGraffiti: /* csgo_thai.txt */"กราฟฟิตี้แบบปิดผนึก",
   ItemSwapStatTrakAccept: /* csgo_thai.txt */"ยอมรับ",
   ItemSwapStatTrakClose: /* csgo_thai.txt */"ปิด",
   ItemSwapStatTrakDesc: /* csgo_thai.txt */"ไอเท็มนี้จะสลับค่า StatTrak™ ระหว่างไอเท็มประเภทเดียวกันสองชิ้น",

--- a/app/translations/turkish.ts
+++ b/app/translations/turkish.ts
@@ -257,6 +257,7 @@ export const turkish = {
   ItemRarityNameTool: /* csgo_turkish.txt */"Araç",
   ItemRarityRare: /* csgo_turkish.txt */"Yüksek Sınıf",
   ItemRarityUncommon: /* csgo_turkish.txt */"Orta Sınıf",
+  ItemSealedGraffiti: /* csgo_turkish.txt */"Mühürlü Grafiti",
   ItemSwapStatTrakAccept: /* csgo_turkish.txt */"KABUL ET",
   ItemSwapStatTrakClose: /* csgo_turkish.txt */"Kapat",
   ItemSwapStatTrakDesc: /* csgo_turkish.txt */"Bu eşya aynı iki eşya arasındaki StatTrak™ değerlerini değiştirir.",

--- a/app/translations/turkish.ts
+++ b/app/translations/turkish.ts
@@ -220,6 +220,7 @@ export const turkish = {
   InventoryItemUnequipCT: "CT'den çıkar",
   InventoryItemUnequipT: "T'den çıkar",
   InventoryItemUnlockContainer: /* csgo_turkish.txt */"Kasayı Aç",
+  InventoryItemUnsealGraffiti: /* csgo_turkish.txt */"Aç ve Kuşan",
   InventoryItemUseItem: /* csgo_turkish.txt */"Eşyayı Kullan",
   InventoryItemUseStorageUnit: /* csgo_turkish.txt */"Bu Depoyu Kullanmaya Başla",
   InventoryItemWear: "Yıpranma:",
@@ -347,5 +348,10 @@ export const turkish = {
   UnpackClose: /* csgo_turkish.txt */"Kapat",
   UnpackDesc: /* csgo_turkish.txt */"Bu eşyayı açmak istediğine emin misin?",
   UnpackNumberOfItems: /* csgo_turkish.txt */"Eşya Sayısı: {1}",
-  UnpackTitle: /* csgo_turkish.txt */"{1} Aç"
+  UnpackTitle: /* csgo_turkish.txt */"{1} Aç",
+  UnsealGraffitiClose: /* csgo_turkish.txt */"Kapat",
+  UnsealGraffitiDesc: /* csgo_turkish.txt */"Öğesini Aç",
+  UnsealGraffitiTitle: /* csgo_turkish.txt */"Grafitiyi Aç",
+  UnsealGraffitiUse: /* csgo_turkish.txt */"Grafitinin Mührünü Kır",
+  UnsealGraffitiWarn: /* csgo_turkish.txt */"Bu grafitinin mührü sadece bir defa kırılabilir"
 };

--- a/app/translations/turkish.ts
+++ b/app/translations/turkish.ts
@@ -229,6 +229,7 @@ export const turkish = {
   InventorySelectInspectContents: /* csgo_turkish.txt */"Şunun içeriği inceleniyor:",
   InventorySelectItemToDeposit: /* csgo_turkish.txt */"Şuraya kaldırılacak eşyaları seç:",
   InventorySelectItemToRetrieve: /* csgo_turkish.txt */"Alınacak eşyaları seç",
+  ItemGraffitiChargesRemaining: /* csgo_turkish.txt */"Kalan Kullanım: {1}",
   ItemRarityAncient: /* csgo_turkish.txt */"Olağandışı",
   ItemRarityCommon: /* csgo_turkish.txt */"Temel Sınıf",
   ItemRarityDefault: /* csgo_turkish.txt */"Varsayılan",

--- a/app/translations/turkish.ts
+++ b/app/translations/turkish.ts
@@ -258,6 +258,7 @@ export const turkish = {
   ItemRarityRare: /* csgo_turkish.txt */"Yüksek Sınıf",
   ItemRarityUncommon: /* csgo_turkish.txt */"Orta Sınıf",
   ItemSealedGraffiti: /* csgo_turkish.txt */"Mühürlü Grafiti",
+  ItemSealedGraffitiDesc: /* csgo_turkish.txt */"Bu bir grafiti kalıbının mühürlü kasasıdır. Bu kasanın mührü bozulduğunda, içinden çıkan kalıp 50 defa kullanılabilir.",
   ItemSwapStatTrakAccept: /* csgo_turkish.txt */"KABUL ET",
   ItemSwapStatTrakClose: /* csgo_turkish.txt */"Kapat",
   ItemSwapStatTrakDesc: /* csgo_turkish.txt */"Bu eşya aynı iki eşya arasındaki StatTrak™ değerlerini değiştirir.",

--- a/app/translations/ukrainian.ts
+++ b/app/translations/ukrainian.ts
@@ -258,6 +258,7 @@ export const ukrainian = {
   ItemRarityRare: /* csgo_ukrainian.txt */"дуже рідкісний предмет",
   ItemRarityUncommon: /* csgo_ukrainian.txt */"рідкісний предмет",
   ItemSealedGraffiti: /* csgo_ukrainian.txt */"Запечатане графіті",
+  ItemSealedGraffitiDesc: /* csgo_ukrainian.txt */"Це запечатаний контейнер із шаблоном графіті. Після розпечатування шаблону ви отримаєте можливість застосувати шаблон 50 разів у ігровому світі.",
   ItemSwapStatTrakAccept: /* csgo_ukrainian.txt */"ПРИЙНЯТИ",
   ItemSwapStatTrakClose: /* csgo_ukrainian.txt */"Закрити",
   ItemSwapStatTrakDesc: /* csgo_ukrainian.txt */"Цей інструмент міняє місцями лічильники СтатТрек™ у двох екземплярів однакової зброї.",

--- a/app/translations/ukrainian.ts
+++ b/app/translations/ukrainian.ts
@@ -220,6 +220,7 @@ export const ukrainian = {
   InventoryItemUnequipCT: "Зняти екіпіровку CT",
   InventoryItemUnequipT: "Зняти екіпіровку T",
   InventoryItemUnlockContainer: /* csgo_ukrainian.txt */"Розкрити",
+  InventoryItemUnsealGraffiti: /* csgo_ukrainian.txt */"Відкрити і спорядити",
   InventoryItemUseItem: /* csgo_ukrainian.txt */"Використати предмет",
   InventoryItemUseStorageUnit: /* csgo_ukrainian.txt */"Почати використовувати це сховище",
   InventoryItemWear: "Зношеність:",
@@ -347,5 +348,10 @@ export const ukrainian = {
   UnpackClose: /* csgo_ukrainian.txt */"Закрити",
   UnpackDesc: /* csgo_ukrainian.txt */"Ви дійсно бажаєте розпакувати цей предмет?",
   UnpackNumberOfItems: /* csgo_ukrainian.txt */"Кількість предметів: {1}",
-  UnpackTitle: /* csgo_ukrainian.txt */"Розпакувати: {1}"
+  UnpackTitle: /* csgo_ukrainian.txt */"Розпакувати: {1}",
+  UnsealGraffitiClose: /* csgo_ukrainian.txt */"Закрити",
+  UnsealGraffitiDesc: /* csgo_ukrainian.txt */"Відкрити",
+  UnsealGraffitiTitle: /* csgo_ukrainian.txt */"Відкрити графіті",
+  UnsealGraffitiUse: /* csgo_ukrainian.txt */"Відкрити графіті",
+  UnsealGraffitiWarn: /* csgo_ukrainian.txt */"Це графіти можна відкрити лише раз"
 };

--- a/app/translations/ukrainian.ts
+++ b/app/translations/ukrainian.ts
@@ -257,6 +257,7 @@ export const ukrainian = {
   ItemRarityNameTool: /* csgo_ukrainian.txt */"Інструмент",
   ItemRarityRare: /* csgo_ukrainian.txt */"дуже рідкісний предмет",
   ItemRarityUncommon: /* csgo_ukrainian.txt */"рідкісний предмет",
+  ItemSealedGraffiti: /* csgo_ukrainian.txt */"Запечатане графіті",
   ItemSwapStatTrakAccept: /* csgo_ukrainian.txt */"ПРИЙНЯТИ",
   ItemSwapStatTrakClose: /* csgo_ukrainian.txt */"Закрити",
   ItemSwapStatTrakDesc: /* csgo_ukrainian.txt */"Цей інструмент міняє місцями лічильники СтатТрек™ у двох екземплярів однакової зброї.",

--- a/app/translations/ukrainian.ts
+++ b/app/translations/ukrainian.ts
@@ -229,6 +229,7 @@ export const ukrainian = {
   InventorySelectInspectContents: /* csgo_ukrainian.txt */"Огляд вмісту:",
   InventorySelectItemToDeposit: /* csgo_ukrainian.txt */"Оберіть предмети для переносу до",
   InventorySelectItemToRetrieve: /* csgo_ukrainian.txt */"Дістати предмети:",
+  ItemGraffitiChargesRemaining: /* csgo_ukrainian.txt */"Зарядів залишилося: {1}",
   ItemRarityAncient: /* csgo_ukrainian.txt */"надзвичайний предмет",
   ItemRarityCommon: /* csgo_ukrainian.txt */"звичайний предмет",
   ItemRarityDefault: /* csgo_ukrainian.txt */"стандартний предмет",

--- a/app/translations/vietnamese.ts
+++ b/app/translations/vietnamese.ts
@@ -229,6 +229,7 @@ export const vietnamese = {
   InventorySelectInspectContents: /* csgo_vietnamese.txt */"Xem vật phẩm bên trong",
   InventorySelectItemToDeposit: /* csgo_vietnamese.txt */"Chọn các món để chuyển vào",
   InventorySelectItemToRetrieve: /* csgo_vietnamese.txt */"Chọn các món để lấy ra",
+  ItemGraffitiChargesRemaining: /* csgo_vietnamese.txt */"Lần dùng còn lại: {1}",
   ItemRarityAncient: /* csgo_vietnamese.txt */"Phi thường",
   ItemRarityCommon: /* csgo_vietnamese.txt */"Hạng cơ bản",
   ItemRarityDefault: /* csgo_vietnamese.txt */"Mặc định",

--- a/app/translations/vietnamese.ts
+++ b/app/translations/vietnamese.ts
@@ -257,6 +257,7 @@ export const vietnamese = {
   ItemRarityNameTool: /* csgo_vietnamese.txt */"Dụng cụ",
   ItemRarityRare: /* csgo_vietnamese.txt */"Hạng cao cấp",
   ItemRarityUncommon: /* csgo_vietnamese.txt */"Hạng trung bình",
+  ItemSealedGraffiti: /* csgo_vietnamese.txt */"Graffiti nguyên bọc",
   ItemSwapStatTrakAccept: /* csgo_vietnamese.txt */"CHẤP NHẬN",
   ItemSwapStatTrakClose: /* csgo_vietnamese.txt */"Đóng",
   ItemSwapStatTrakDesc: /* csgo_vietnamese.txt */"Vật phẩm sẽ đổi giá trị StatTrak™ giữa hai vật phẩm trong cùng thể loại.",

--- a/app/translations/vietnamese.ts
+++ b/app/translations/vietnamese.ts
@@ -258,6 +258,7 @@ export const vietnamese = {
   ItemRarityRare: /* csgo_vietnamese.txt */"Hạng cao cấp",
   ItemRarityUncommon: /* csgo_vietnamese.txt */"Hạng trung bình",
   ItemSealedGraffiti: /* csgo_vietnamese.txt */"Graffiti nguyên bọc",
+  ItemSealedGraffitiDesc: /* csgo_vietnamese.txt */"Đây là một gói niêm phong chứa hình vẽ graffiti. Một khi mở niêm phong, nó sẽ cho bạn 50 lần vẽ graffiti đó lên thế giới trong trò chơi.",
   ItemSwapStatTrakAccept: /* csgo_vietnamese.txt */"CHẤP NHẬN",
   ItemSwapStatTrakClose: /* csgo_vietnamese.txt */"Đóng",
   ItemSwapStatTrakDesc: /* csgo_vietnamese.txt */"Vật phẩm sẽ đổi giá trị StatTrak™ giữa hai vật phẩm trong cùng thể loại.",

--- a/app/translations/vietnamese.ts
+++ b/app/translations/vietnamese.ts
@@ -220,6 +220,7 @@ export const vietnamese = {
   InventoryItemUnequipCT: "Gỡ trang bị CT",
   InventoryItemUnequipT: "Gỡ trang bị T",
   InventoryItemUnlockContainer: /* csgo_vietnamese.txt */"Mở khóa",
+  InventoryItemUnsealGraffiti: /* csgo_vietnamese.txt */"Mở và dán vào",
   InventoryItemUseItem: /* csgo_vietnamese.txt */"Sử dụng vật phẩm",
   InventoryItemUseStorageUnit: /* csgo_vietnamese.txt */"Bắt đầu dùng thùng này",
   InventoryItemWear: "Độ mòn:",
@@ -347,5 +348,10 @@ export const vietnamese = {
   UnpackClose: /* csgo_vietnamese.txt */"Đóng",
   UnpackDesc: /* csgo_vietnamese.txt */"Bạn có chắc mình muốn mở gói vật phẩm này?",
   UnpackNumberOfItems: /* csgo_vietnamese.txt */"Số món: {1}",
-  UnpackTitle: /* csgo_vietnamese.txt */"Mở gói {1}"
+  UnpackTitle: /* csgo_vietnamese.txt */"Mở gói {1}",
+  UnsealGraffitiClose: /* csgo_vietnamese.txt */"Đóng",
+  UnsealGraffitiDesc: /* csgo_vietnamese.txt */"Mở bọc",
+  UnsealGraffitiTitle: /* csgo_vietnamese.txt */"Mở graffiti",
+  UnsealGraffitiUse: /* csgo_vietnamese.txt */"Mở bọc graffiti",
+  UnsealGraffitiWarn: /* csgo_vietnamese.txt */"Graffiti này chỉ có thể mở bọc một lần"
 };

--- a/app/utils/inventory-transform.ts
+++ b/app/utils/inventory-transform.ts
@@ -67,18 +67,14 @@ export function sortByName(
   return a.item.name.localeCompare(b.item.name);
 }
 
-function getTypeOrder(item: CS2InventoryItem) {
-  if (item.isStickerDisplayCase()) {
-    return INVENTORY_ITEM_TYPE_ORDER[CS2ItemType.Sticker] + 0.5;
-  }
-  return INVENTORY_ITEM_TYPE_ORDER[item.type];
-}
-
 export function sortByType(
   a: TransformedInventoryItem,
   b: TransformedInventoryItem
 ) {
-  return getTypeOrder(a.item) - getTypeOrder(b.item);
+  return (
+    INVENTORY_ITEM_TYPE_ORDER[a.item.type] -
+    INVENTORY_ITEM_TYPE_ORDER[b.item.type]
+  );
 }
 
 export function sortByEquipped(

--- a/docs/api.md
+++ b/docs/api.md
@@ -196,6 +196,33 @@ type PostIncrementItemStatTrakRequest = {
 - Returns `400` when the user does not exist or target uid is invalid.
 - Returns `204` when the increment was successful.
 
+## Consume item Spray
+
+```http
+POST https://inventory.cstrike.app/api/consume-item-spray
+```
+
+Consumes a charge of an unsealed graffiti. The item is removed from the inventory when its last charge is consumed.
+
+### Request
+
+> [!IMPORTANT]  
+> API key must have `api` or `spray_consume` scope.
+
+```typescript
+type PostConsumeItemSprayRequest = {
+  apiKey: string;
+  targetUid: number;
+  userId: string;
+};
+```
+
+### Response
+
+- Returns `401` when using an invalid API key.
+- Returns `400` when the user does not exist or target uid is not an unsealed graffiti with charges.
+- Returns `204` when the charge was consumed.
+
 ## Add Item
 
 ```http

--- a/docs/api.md
+++ b/docs/api.md
@@ -193,7 +193,7 @@ type PostIncrementItemStatTrakRequest = {
 ### Response
 
 - Returns `401` when using an invalid API key.
-- Returns `400` when the user does not exist or target uid is invalid.
+- Returns `400` when the user does not exist, target uid is invalid, or the item is not equipped.
 - Returns `204` when the increment was successful.
 
 ## Consume item Spray
@@ -220,7 +220,7 @@ type PostConsumeItemSprayRequest = {
 ### Response
 
 - Returns `401` when using an invalid API key.
-- Returns `400` when the user does not exist or target uid is not an unsealed graffiti with charges.
+- Returns `400` when the user does not exist or target uid is not an equipped, unsealed graffiti with charges.
 - Returns `204` when the charge was consumed.
 
 ## Add Item

--- a/scripts/translate.ts
+++ b/scripts/translate.ts
@@ -257,6 +257,7 @@ const STRINGS_FROM_GAME: Record<string, string | string[] | {
   ItemRarityNameTool: "CSGO_Type_Tool",
   ItemRarityRare: "Rarity_Rare",
   ItemRarityUncommon: "Rarity_Uncommon",
+  ItemSealedGraffiti: "CSGO_Tool_Spray",
   ItemSwapStatTrakAccept: "SFUI_Accept",
   ItemSwapStatTrakClose: "GameUI_Close",
   ItemSwapStatTrakDesc: "CSGO_tool_stattrak_swap_desc",

--- a/scripts/translate.ts
+++ b/scripts/translate.ts
@@ -229,6 +229,7 @@ const STRINGS_FROM_GAME: Record<string, string | string[] | {
   InventorySelectInspectContents: "inv_select_casketcontents",
   InventorySelectItemToDeposit: "inv_select_casketstore",
   InventorySelectItemToRetrieve: "inv_select_casketretrieve",
+  ItemGraffitiChargesRemaining: { token: "Attrib_SpraysRemaining", transform: (value) => replace(value, '%s1', '{1}') },
   ItemRarityAncient: "Rarity_Ancient",
   ItemRarityCommon: "Rarity_Common",
   ItemRarityDefault: "Rarity_Default",

--- a/scripts/translate.ts
+++ b/scripts/translate.ts
@@ -222,6 +222,7 @@ const STRINGS_FROM_GAME: Record<string, string | string[] | {
   InventoryItemTeamT: "CSGO_Inventory_Team_T",
   InventoryItemUnequip: "SFUI_InvContextMenu_Unequip",
   InventoryItemUnlockContainer: "inv_context_open_package",
+  InventoryItemUnsealGraffiti: "SFUI_InvContextMenu_usespray",
   InventoryItemUseItem: "inv_context_useitem",
   InventoryItemUseStorageUnit: "inv_context_newcasket",
   InventorySelectAnItem: "inv_select_item_use",
@@ -316,6 +317,11 @@ const STRINGS_FROM_GAME: Record<string, string | string[] | {
   UnpackDesc: "popup_useitem_desc_getkeychaincharges",
   UnpackNumberOfItems: { token: "Attrib_ItemsCount", transform: (value) => replace(value, '%s1', '{1}') },
   UnpackTitle: { token: "popup_useitem_title_getkeychaincharges", transform: (value) => replace(value, '{s:itemname}', '{1}') },
+  UnsealGraffitiClose: "GameUI_Close",
+  UnsealGraffitiDesc: { token: "popup_decodeable_desc_graffiti", transform: (value) => replace(value, '<b>{s:itemname}</b>', '') },
+  UnsealGraffitiTitle: "popup_totool_decodeable_header_graffiti",
+  UnsealGraffitiUse: "popup_decodeable_button_graffiti",
+  UnsealGraffitiWarn: "popup_decodeable_warning_graffiti",
 };
 
 assert(CS2_CSGO_PATH, "CS2_CSGO_PATH must be set.");

--- a/scripts/translate.ts
+++ b/scripts/translate.ts
@@ -258,6 +258,7 @@ const STRINGS_FROM_GAME: Record<string, string | string[] | {
   ItemRarityRare: "Rarity_Rare",
   ItemRarityUncommon: "Rarity_Uncommon",
   ItemSealedGraffiti: "CSGO_Tool_Spray",
+  ItemSealedGraffitiDesc: { token: "CSGO_Tool_Spray_Desc", transform: (value) => value.replace(/<\/?b>/g, '') },
   ItemSwapStatTrakAccept: "SFUI_Accept",
   ItemSwapStatTrakClose: "GameUI_Close",
   ItemSwapStatTrakDesc: "CSGO_tool_stattrak_swap_desc",


### PR DESCRIPTION
- **Display sealed graffiti name for graffitis with charges**
- **Show sealed container description when inspecting sealed graffiti**
- **Add Open and Equip button when inspecting sealed graffiti**
- **Show remaining charges when inspecting unsealed graffiti**
- **Add API for consuming spray charges**
- **Add spray consume API and require equipped items on item APIs**
- **Name economy graffiti items as sealed**
- **Show remaining charges in inventory item tooltip**
